### PR TITLE
Fixed broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,4 +121,4 @@ it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-See [LICENSE.txt](https://github.com/amspath/slideviewer/blob/master/LICENSE.txt) for more information.
+See [LICENSE.txt](https://github.com/amspath/slidescape/blob/master/LICENSE.txt) for more information.


### PR DESCRIPTION
I assume that this repo has changed name. This resulted in the LICENSE link in the README to be broken.

I have fixed it now.