### PR TITLE
draft: fix build on linux-aarch64

### DIFF
--- a/src/platform/intrinsics.h
+++ b/src/platform/intrinsics.h
@@ -36,7 +36,7 @@
 #elif defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))
 /* GCC-compatible compiler, targeting x86/x86-64 */
 #include <x86intrin.h>
-#elif defined(__GNUC__) && defined(__ARM_NEON__)
+#elif defined(__GNUC__) && (defined(__ARM_NEON__) || defined(__ARM_NEON))
 /* GCC-compatible compiler, targeting ARM with NEON */
      #include <arm_neon.h>
 #elif defined(__GNUC__) && defined(__IWMMXT__)
@@ -146,7 +146,7 @@ static inline u32 atomic_or(volatile u32* x, u32 mask) {
 }
 
 static inline u32 bit_scan_forward(u32 x) {
-	return _bit_scan_forward(x);
+	return __builtin_ctz(x);
 }
 
 #endif
@@ -337,6 +337,6 @@ static inline i32 popcount(u32 x) {
 }
 #else
 static inline i32 popcount(u32 x) {
-    return _popcnt32(x);
+    return __builtin_popcount(x);
 }
 #endif

--- a/src/third_party/ltalloc.cc
+++ b/src/third_party/ltalloc.cc
@@ -210,7 +210,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #		define PAUSE __asm__ __volatile__("rd    %%ccr, %%g0\n\t" ::: "memory")
 #	elif defined(__ppc__)  || defined(_ARCH_PPC) || defined(_ARCH_PWR) || defined(_ARCH_PWR2) || defined(_POWER)
 #		define PAUSE __asm__ __volatile__("or 27,27,27")
-#	elif defined(__ANDROID__) || defined(__arm64)
+#	elif defined(__ANDROID__) || defined(__arm64) || defined(__aarch64__)
 #		include <sched.h> //for sched_yield
 #		define PAUSE sched_yield()
 #	else


### PR DESCRIPTION
Applies fixes from https://github.com/amspath/libisyntax/pull/54 to fix build on aarch64-linux.

TODO: error in linking stage - undefined symbol for `copy_cstring`.