### PR TITLE
Improved iSyntax v2 support

### DIFF
--- a/src/core/console.cpp
+++ b/src/core/console.cpp
@@ -147,29 +147,29 @@ void console_execute_command(app_state_t* app_state, const char* command) {
 		} else if (strcmp(cmd, "clear") == 0) {
 			console_clear_log();
 		} else if (strcmp(cmd, "macro") == 0) {
-			draw_macro_image_in_background = !draw_macro_image_in_background;
-			if (draw_macro_image_in_background) {
+			app_state->scene.draw_macro_image = !app_state->scene.draw_macro_image;
+			if (app_state->scene.draw_macro_image) {
 				console_print("Enabled macro image display");
 			} else {
 				console_print("Disabled macro image display");
 			}
 		} else if (strcmp(cmd, "label") == 0) {
-			draw_label_image_in_background = !draw_label_image_in_background;
-			if (draw_macro_image_in_background) {
+			app_state->scene.draw_label_image = !app_state->scene.draw_label_image;
+			if (app_state->scene.draw_label_image) {
 				console_print("Enabled label image display");
 			} else {
 				console_print("Disabled label image display");
 			}
 		} else if (strcmp(cmd, "grid") == 0) {
 			app_state->scene.enable_grid = !app_state->scene.enable_grid;
-			if (draw_macro_image_in_background) {
+			if (app_state->scene.enable_grid) {
 				console_print("Enabled grid");
 			} else {
 				console_print("Disabled grid");
 			}
 		} else if (strcmp(cmd, "scalebar") == 0) {
 			app_state->scene.scale_bar.enabled = !app_state->scene.scale_bar.enabled;
-			if (draw_macro_image_in_background) {
+			if (app_state->scene.scale_bar.enabled) {
 				console_print("Enabled scale bar");
 			} else {
 				console_print("Disabled scale bar");

--- a/src/core/console.cpp
+++ b/src/core/console.cpp
@@ -153,6 +153,13 @@ void console_execute_command(app_state_t* app_state, const char* command) {
 			} else {
 				console_print("Disabled wsi image display");
 			}
+		} else if (strcmp(cmd, "wsi-background") == 0) {
+			app_state->scene.draw_wsi_background = !app_state->scene.draw_wsi_background;
+			if (app_state->scene.draw_wsi_background) {
+				console_print("Enabled wsi background display");
+			} else {
+				console_print("Disabled wsi background display");
+			}
 		} else if (strcmp(cmd, "macro") == 0) {
 			app_state->scene.draw_macro_image = !app_state->scene.draw_macro_image;
 			if (app_state->scene.draw_macro_image) {

--- a/src/core/console.cpp
+++ b/src/core/console.cpp
@@ -146,6 +146,13 @@ void console_execute_command(app_state_t* app_state, const char* command) {
 			}
 		} else if (strcmp(cmd, "clear") == 0) {
 			console_clear_log();
+		} else if (strcmp(cmd, "wsi") == 0) {
+			app_state->scene.draw_wsi_image = !app_state->scene.draw_wsi_image;
+			if (app_state->scene.draw_wsi_image) {
+				console_print("Enabled wsi image display");
+			} else {
+				console_print("Disabled wsi image display");
+			}
 		} else if (strcmp(cmd, "macro") == 0) {
 			app_state->scene.draw_macro_image = !app_state->scene.draw_macro_image;
 			if (app_state->scene.draw_macro_image) {

--- a/src/core/gui.cpp
+++ b/src/core/gui.cpp
@@ -1204,6 +1204,7 @@ void gui_draw(app_state_t* app_state, input_t* input, i32 client_width, i32 clie
 				app_state->scene.cos_rotation = 1.0f;
 			}
             ImGui::Checkbox("Draw tile outlines", &app_state->scene.draw_outlines);
+            ImGui::Checkbox("Draw envelopes (iSyntax v2)", &app_state->scene.draw_envelopes);
 
             // Options for adjusting level offsets
             if (arrlen(app_state->loaded_images) > 0) {

--- a/src/core/gui.cpp
+++ b/src/core/gui.cpp
@@ -1203,6 +1203,7 @@ void gui_draw(app_state_t* app_state, input_t* input, i32 client_width, i32 clie
 				app_state->scene.sin_rotation = 0.0f;
 				app_state->scene.cos_rotation = 1.0f;
 			}
+            ImGui::Checkbox("Draw WSI image", &app_state->scene.draw_wsi_image);
             ImGui::Checkbox("Draw label image", &app_state->scene.draw_label_image);
             ImGui::Checkbox("Draw macro image", &app_state->scene.draw_macro_image);
             ImGui::Checkbox("Draw tile outlines", &app_state->scene.draw_outlines);

--- a/src/core/gui.cpp
+++ b/src/core/gui.cpp
@@ -1204,10 +1204,11 @@ void gui_draw(app_state_t* app_state, input_t* input, i32 client_width, i32 clie
 				app_state->scene.cos_rotation = 1.0f;
 			}
             ImGui::Checkbox("Draw WSI image", &app_state->scene.draw_wsi_image);
+            ImGui::Checkbox("Draw WSI background", &app_state->scene.draw_wsi_background);
             ImGui::Checkbox("Draw label image", &app_state->scene.draw_label_image);
             ImGui::Checkbox("Draw macro image", &app_state->scene.draw_macro_image);
             ImGui::Checkbox("Draw tile outlines", &app_state->scene.draw_outlines);
-            ImGui::Checkbox("Draw envelopes (iSyntax v2)", &app_state->scene.draw_envelopes);
+            ImGui::Checkbox("Draw clip rectangles", &app_state->scene.draw_envelopes);
 
             // Options for adjusting level offsets
             if (arrlen(app_state->loaded_images) > 0) {

--- a/src/core/gui.cpp
+++ b/src/core/gui.cpp
@@ -1203,6 +1203,8 @@ void gui_draw(app_state_t* app_state, input_t* input, i32 client_width, i32 clie
 				app_state->scene.sin_rotation = 0.0f;
 				app_state->scene.cos_rotation = 1.0f;
 			}
+            ImGui::Checkbox("Draw label image", &app_state->scene.draw_label_image);
+            ImGui::Checkbox("Draw macro image", &app_state->scene.draw_macro_image);
             ImGui::Checkbox("Draw tile outlines", &app_state->scene.draw_outlines);
             ImGui::Checkbox("Draw envelopes (iSyntax v2)", &app_state->scene.draw_envelopes);
 

--- a/src/core/image.c
+++ b/src/core/image.c
@@ -156,6 +156,12 @@ bool init_image_from_tiff(image_t* image, tiff_t tiff, bool is_overlay, image_t*
     image->width_in_um = tiff.main_image_ifd->image_width * tiff.mpp_x;
     image->height_in_pixels = tiff.main_image_ifd->image_height;
     image->height_in_um = tiff.main_image_ifd->image_height * tiff.mpp_y;
+
+    image->clip_rects[image->clip_rect_count] = RECT2F(
+        0.0, 0.0, image->width_in_um, image->height_in_um
+    );
+    image->clip_rect_count +=1;
+
     // TODO: fix code duplication with tiff_deserialize()
     if (tiff.level_image_ifd_count > 0 && tiff.main_image_ifd->tile_width) {
 
@@ -331,6 +337,26 @@ bool init_image_from_isyntax(image_t* image, isyntax_t* isyntax, bool is_overlay
     image->width_in_um = wsi_image->width * isyntax->mpp_x;
     image->height_in_pixels = wsi_image->height;
     image->height_in_um = wsi_image->height * isyntax->mpp_y;
+
+    // Construct clipping rectangles from valid data envelopes 
+    if(isyntax->valid_data_envelope_rectangle_count == 0){ // iSyntax v1
+        image->clip_rects[image->clip_rect_count] = RECT2F(
+            0.0, 0.0, image->width_in_um, image->height_in_um
+        );
+        image->clip_rect_count +=1;
+    } else { // iSyntax v2
+        for (i32 i = 0; i < isyntax->valid_data_envelope_rectangle_count; ++i){
+            rect2i* rectangle = &isyntax->valid_data_envelopes_rectangles[i];
+            image->clip_rects[image->clip_rect_count] = RECT2F(
+                rectangle->x * image->mpp_x,
+                rectangle->y * image->mpp_y,
+                rectangle->w * image->mpp_x,
+                rectangle->h * image->mpp_y
+            );
+            image->clip_rect_count +=1;
+        }
+    }
+
     // TODO: fix code duplication with tiff_deserialize()
     if (wsi_image->level_count > 0 && isyntax->tile_width) {
 
@@ -460,6 +486,12 @@ bool init_image_from_dicom(image_t* image, dicom_series_t* dicom, bool is_overla
     image->width_in_um = base_level_instance->total_pixel_matrix_columns * image->mpp_x;
     image->height_in_pixels = base_level_instance->total_pixel_matrix_rows;
     image->height_in_um = base_level_instance->total_pixel_matrix_rows * image->mpp_y;
+
+    image->clip_rects[image->clip_rect_count] = RECT2F(
+        0.0, 0.0, image->width_in_um, image->height_in_um
+    );
+    image->clip_rect_count +=1;
+
     // TODO: fix code duplication with tiff_deserialize()
     if (dicom->wsi.instance_count > 0 && image->tile_width) {
 
@@ -608,6 +640,12 @@ bool init_image_from_mrxs(image_t* image, mrxs_t* mrxs, bool is_overlay) {
 	image->width_in_um = image->width_in_pixels * image->mpp_x;
 	image->height_in_pixels = mrxs->tile_height * mrxs->base_height_in_tiles;
 	image->height_in_um = image->height_in_pixels * image->mpp_y;
+
+    image->clip_rects[image->clip_rect_count] = RECT2F(
+        0.0, 0.0, image->width_in_um, image->height_in_um
+    );
+    image->clip_rect_count +=1;
+
 	// TODO: fix code duplication with tiff_deserialize()
 	if (mrxs->level_count > 0 && image->tile_width) {
 
@@ -721,6 +759,11 @@ bool init_image_from_stbi(image_t* image, simple_image_t* simple, bool is_overla
     image->height_in_pixels = simple->height;
     image->height_in_um = (float)simple->height * image->mpp_y;
 
+    image->clip_rects[image->clip_rect_count] = RECT2F(
+        0.0, 0.0, image->width_in_um, image->height_in_um
+    );
+    image->clip_rect_count +=1;
+
     image->level_count = 1;
     level_image_t* level_image = image->level_images + 0;
     memset(level_image, 0, sizeof(*level_image));
@@ -777,6 +820,12 @@ void init_image_from_openslide(image_t* image, wsi_t* wsi, bool is_overlay) {
     image->width_in_um = (float)wsi->width * wsi->mpp_x;
     image->height_in_pixels = wsi->height;
     image->height_in_um = (float)wsi->height * wsi->mpp_y;
+
+    image->clip_rects[image->clip_rect_count] = RECT2F(
+        0.0, 0.0, image->width_in_um, image->height_in_um
+    );
+    image->clip_rect_count +=1;
+
     ASSERT(wsi->levels[0].x_tile_side_in_um > 0);
     if (wsi->level_count > 0 && wsi->levels[0].x_tile_side_in_um > 0) {
         ASSERT(wsi->max_downsample_level >= 0);

--- a/src/core/image.c
+++ b/src/core/image.c
@@ -392,6 +392,7 @@ bool init_image_from_isyntax(image_t* image, isyntax_t* isyntax, bool is_overlay
             image->macro_image.pixels = pixels;
             image->macro_image.width = macro_image->width;
             image->macro_image.height = macro_image->height;
+            console_print("%d", image->macro_image.mpp);
             image->macro_image.mpp = 0.0315f * 1000.0f; // apparently, always this value
             image->macro_image.world_pos.x = -((float)(wsi_image->offset_x + wsi_image->level0_padding) * isyntax->mpp_x);
             image->macro_image.world_pos.y = -((float)(wsi_image->offset_y + wsi_image->level0_padding) * isyntax->mpp_y);

--- a/src/core/image.c
+++ b/src/core/image.c
@@ -392,10 +392,18 @@ bool init_image_from_isyntax(image_t* image, isyntax_t* isyntax, bool is_overlay
             image->macro_image.pixels = pixels;
             image->macro_image.width = macro_image->width;
             image->macro_image.height = macro_image->height;
-            console_print("%d", image->macro_image.mpp);
-            image->macro_image.mpp = 0.0315f * 1000.0f; // apparently, always this value
-            image->macro_image.world_pos.x = -((float)(wsi_image->offset_x + wsi_image->level0_padding) * isyntax->mpp_x);
-            image->macro_image.world_pos.y = -((float)(wsi_image->offset_y + wsi_image->level0_padding) * isyntax->mpp_y);
+            if(macro_image->is_mpp_known){
+                image->macro_image.mpp = macro_image->mpp_x; // not always, in version >100 mpp are provided for macro and label images (value around 27.0)
+            }else{
+                image->macro_image.mpp = 0.0315f * 1000.0f; // apparently, always this value
+            }
+            if(macro_image->origin_x == 0 || macro_image->origin_y == 0){ // version 5
+                image->macro_image.world_pos.x = -((float)(wsi_image->offset_x + wsi_image->level0_padding) * isyntax->mpp_x);
+                image->macro_image.world_pos.y = -((float)(wsi_image->offset_y + wsi_image->level0_padding) * isyntax->mpp_y);
+            }else{ // version >100
+                image->macro_image.world_pos.x = (float)(macro_image->origin_x);
+                image->macro_image.world_pos.y = (float)(macro_image->origin_y);
+            }
             image->macro_image.is_valid = true;
         }
     }
@@ -406,11 +414,14 @@ bool init_image_from_isyntax(image_t* image, isyntax_t* isyntax, bool is_overlay
             image->label_image.pixels = pixels;
             image->label_image.width = label_image->width;
             image->label_image.height = label_image->height;
-            image->label_image.mpp = 0.0315f * 1000.0f; // apparently, always this value
+            if(label_image->is_mpp_known){
+                image->label_image.mpp = label_image->mpp_x; // not always, in version >100 mpp are provided for macro and label images
+            }else{
+                image->label_image.mpp = 0.0315f * 1000.0f; // apparently, always this value
+            }
 			if (image->macro_image.is_valid) {
 				image->label_image.world_pos.x = image->macro_image.world_pos.x // macro image left side (origin)
-					+ image->macro_image.width * image->macro_image.mpp // macro image right side
-					+ image->label_image.width * image->label_image.mpp; // add label height (will rotate 90 degrees to the right to 'fit' in place)
+					+ image->macro_image.width * image->macro_image.mpp; // macro image right side
 				image->label_image.world_pos.y = image->macro_image.world_pos.y;
 			}
 	        image->label_image.is_valid = true;

--- a/src/core/image.h
+++ b/src/core/image.h
@@ -159,6 +159,8 @@ typedef struct image_t {
     char directory[512];
     image_type_enum type;
     image_backend_enum backend;
+    rect2f clip_rects[64];
+    i32 clip_rect_count;
     bool is_freshly_loaded; // TODO: remove or refactor, is this still needed?
     bool is_local; // i.e. not remote (accessed over network using client/server interface)
     bool is_valid;

--- a/src/core/image.h
+++ b/src/core/image.h
@@ -159,7 +159,7 @@ typedef struct image_t {
     char directory[512];
     image_type_enum type;
     image_backend_enum backend;
-    rect2f clip_rects[64];
+    rect2f clip_rects[128];
     i32 clip_rect_count;
     bool is_freshly_loaded; // TODO: remove or refactor, is this still needed?
     bool is_local; // i.e. not remote (accessed over network using client/server interface)

--- a/src/core/scene.cpp
+++ b/src/core/scene.cpp
@@ -70,6 +70,7 @@ void init_scene(app_state_t *app_state, scene_t *scene) {
 	scene->transparent_tolerance = 0.01f;
 	scene->use_transparent_filter = false;
     scene->draw_outlines = false;
+	scene->draw_envelopes = false;
 	scene->entity_count = 1; // NOTE: entity 0 = null entity, so start from 1
 	scene->camera = V2F(0.0f, 0.0f); // center camera at origin
 	init_zoom_state(&scene->zoom, 0.0f, 1.0f, 1.0f, 1.0f);

--- a/src/core/scene.cpp
+++ b/src/core/scene.cpp
@@ -72,6 +72,7 @@ void init_scene(app_state_t *app_state, scene_t *scene) {
     scene->draw_outlines = false;
 	scene->draw_envelopes = false;
 	scene->draw_wsi_image = true;
+	scene->draw_wsi_background = true;
 	scene->draw_macro_image = true;
 	scene->draw_label_image = true;
 	scene->entity_count = 1; // NOTE: entity 0 = null entity, so start from 1

--- a/src/core/scene.cpp
+++ b/src/core/scene.cpp
@@ -71,6 +71,8 @@ void init_scene(app_state_t *app_state, scene_t *scene) {
 	scene->use_transparent_filter = false;
     scene->draw_outlines = false;
 	scene->draw_envelopes = false;
+	scene->draw_macro_image = true;
+	scene->draw_label_image = true;
 	scene->entity_count = 1; // NOTE: entity 0 = null entity, so start from 1
 	scene->camera = V2F(0.0f, 0.0f); // center camera at origin
 	init_zoom_state(&scene->zoom, 0.0f, 1.0f, 1.0f, 1.0f);

--- a/src/core/scene.cpp
+++ b/src/core/scene.cpp
@@ -71,6 +71,7 @@ void init_scene(app_state_t *app_state, scene_t *scene) {
 	scene->use_transparent_filter = false;
     scene->draw_outlines = false;
 	scene->draw_envelopes = false;
+	scene->draw_wsi_image = true;
 	scene->draw_macro_image = true;
 	scene->draw_label_image = true;
 	scene->entity_count = 1; // NOTE: entity 0 = null entity, so start from 1

--- a/src/core/viewer.cpp
+++ b/src/core/viewer.cpp
@@ -672,6 +672,7 @@ void update_and_render_image(app_state_t* app_state, image_t* image) {
 				pmax.y = macro_image->height * macro_image->mpp;
 
 				mat4x4 model_matrix;
+
 				mat4x4_translate(model_matrix,
 				                 image->origin_offset.x + macro_image->world_pos.x,
 				                 image->origin_offset.y + macro_image->world_pos.y,
@@ -704,38 +705,78 @@ void update_and_render_image(app_state_t* app_state, image_t* image) {
 			}
 		}
 
-		{
-			// Set up the stencil buffer to prevent rendering outside the image area
+		if (scene->draw_wsi_background && image->clip_rect_count > 1){
+
+			// ToDo: de image width and height are not sufficient to contain all data both in iSyntax v1 and v2
+			// why are the width and heights this way / incorrect?
 			bounds2f stencil_bounds = {0, 0, image->width_in_um, image->height_in_um};
 			if (scene->is_cropped) {
 				stencil_bounds = clip_bounds2f(stencil_bounds, scene->crop_bounds);
 			}
 
-			// Take a small bit off the right and bottom edges to prevent rendering black lines at the edge of the image
-			stencil_bounds.right -= 0.1f / image->mpp_x;
-			stencil_bounds.bottom -= 0.1f / image->mpp_y;
-
-			glEnable(GL_STENCIL_TEST);
-			glStencilFunc(GL_ALWAYS, 1, 0xFF);
-			glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
-//			glStencilMask(0xFF);
-			glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE); // don't actually draw the stencil rectangle
-			glDepthMask(GL_FALSE); // don't write to depth buffer
 			{
 				mat4x4 model_matrix;
-				mat4x4_translate(model_matrix, stencil_bounds.left, stencil_bounds.top, 0.0f);
+				mat4x4_translate(model_matrix, stencil_bounds.left, stencil_bounds.top, 5.0f);
 				mat4x4_scale_aniso(model_matrix, model_matrix,
 				                   stencil_bounds.right - stencil_bounds.left,
 				                   stencil_bounds.bottom - stencil_bounds.top,
 				                   1.0f);
 				glUniformMatrix4fv(basic_shader.u_model_matrix, 1, GL_FALSE, &model_matrix[0][0]);
-				draw_rect(dummy_texture);
+				draw_rect(transparent_texture);
+			}
+		}
+
+		if (scene->draw_wsi_image){
+			// Set up the stencil buffer to prevent rendering outside the image area
+			glEnable(GL_STENCIL_TEST);
+			glStencilFunc(GL_ALWAYS, 1, 0xFF);
+			glStencilOp(GL_KEEP, GL_KEEP, GL_INCR);
+//			glStencilMask(0xFF);
+			glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE); // don't actually draw the stencil rectangle
+			glDepthMask(GL_FALSE); // don't write to depth buffer
+
+			for(i32 i=0; i<image->clip_rect_count; ++i){
+				// Remove 1 pixel of the outline to prevent rendering invalid areas / black outlines,
+				// cause the stencil buffer isnt perfect (likely due to rounding errors)
+				// Due to the rectangle being a continuum of eachother, you cannot simply make each individual rectangle smaller
+				// Instead we only want to remove the 'outline' of the rectangles, 
+				// for that purpose we draw one slightly bigger and one slightly smaller rectangle
+				// When a particular pixel is on the outline it will be covered by at most one rectangle
+				// Every other pixel is covered at least two rectangles 
+				// (the pixels on the border between two adjecent rectangles, are covered by the bigger rectangle of the two adjecent rectangles)
+				// (x and y need to be scaled independently, otherwise inner corners are not removed)
+
+				float overlap_x = image->level_images[lowest_visible_scale].um_per_pixel_x * 1.0;
+				float overlap_y = image->level_images[lowest_visible_scale].um_per_pixel_y * 1.0;
+
+				rect2f* clip_rect = &image->clip_rects[i];
+				{
+					mat4x4 model_matrix;
+					mat4x4_translate(model_matrix, clip_rect->x - overlap_x, clip_rect->y + overlap_y, 0.0f);
+					mat4x4_scale_aniso(model_matrix, model_matrix,
+									   clip_rect->w + (2 * overlap_x),
+									   clip_rect->h - (2 * overlap_y),
+									   1.0f);
+					glUniformMatrix4fv(basic_shader.u_model_matrix, 1, GL_FALSE, &model_matrix[0][0]);
+					draw_rect(dummy_texture);
+				}
+				{
+					mat4x4 model_matrix;
+					mat4x4_translate(model_matrix, clip_rect->x + overlap_x, clip_rect->y - overlap_y, 0.0f);
+					mat4x4_scale_aniso(model_matrix, model_matrix,
+									   clip_rect->w - (2 * overlap_x),
+									   clip_rect->h + (2 * overlap_y),
+									   1.0f);
+					glUniformMatrix4fv(basic_shader.u_model_matrix, 1, GL_FALSE, &model_matrix[0][0]);
+					draw_rect(dummy_texture);
+				}
 			}
 
 			glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 			glDepthMask(GL_TRUE);
+			glStencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
 //			glStencilMask(0xFF);
-			glStencilFunc(GL_EQUAL, 1, 0xFF);
+			glStencilFunc(GL_LEQUAL, 2, 0xFF);
 //			glDisable(GL_STENCIL_TEST);
 
 		}
@@ -752,59 +793,60 @@ void update_and_render_image(app_state_t* app_state, image_t* image) {
 
 		// Draw tiles
 		// Draw all levels within the viewport, up to the current zoom factor
-		i32 lowest_level_to_draw = ATLEAST(lowest_visible_scale, global_lowest_scale_to_render);
-		i32 highest_level_to_draw = ATMOST(highest_visible_scale, global_highest_scale_to_render);
-		for (i32 level = lowest_level_to_draw; level <= highest_level_to_draw; ++level) {
-			level_image_t *drawn_level = image->level_images + level;
-			if (!drawn_level->exists) {
-				continue;
-			}
+		if (scene->draw_wsi_image){
+			i32 lowest_level_to_draw = ATLEAST(lowest_visible_scale, global_lowest_scale_to_render);
+			i32 highest_level_to_draw = ATMOST(highest_visible_scale, global_highest_scale_to_render);
+			for (i32 level = lowest_level_to_draw; level <= highest_level_to_draw; ++level) {
+				level_image_t *drawn_level = image->level_images + level;
+				if (!drawn_level->exists) {
+					continue;
+				}
 
-			bounds2i level_tiles_bounds = BOUNDS2I(0, 0, (i32)drawn_level->width_in_tiles, (i32)drawn_level->height_in_tiles);
+				bounds2i level_tiles_bounds = BOUNDS2I(0, 0, (i32)drawn_level->width_in_tiles, (i32)drawn_level->height_in_tiles);
 
-			bounds2i visible_tiles = world_bounds_to_tile_bounds(&scene->camera_bounds, drawn_level->x_tile_side_in_um,
-			                                                     drawn_level->y_tile_side_in_um, image->origin_offset);
-			visible_tiles = clip_bounds2i(visible_tiles, level_tiles_bounds);
+				bounds2i visible_tiles = world_bounds_to_tile_bounds(&scene->camera_bounds, drawn_level->x_tile_side_in_um,
+																	drawn_level->y_tile_side_in_um, image->origin_offset);
+				visible_tiles = clip_bounds2i(visible_tiles, level_tiles_bounds);
 
-			if (scene->is_cropped) {
-				bounds2i crop_tile_bounds = world_bounds_to_tile_bounds(&scene->crop_bounds,
-				                                                        drawn_level->x_tile_side_in_um,
-				                                                        drawn_level->y_tile_side_in_um, image->origin_offset);
-				visible_tiles = clip_bounds2i(visible_tiles, crop_tile_bounds);
-			}
+				if (scene->is_cropped) {
+					bounds2i crop_tile_bounds = world_bounds_to_tile_bounds(&scene->crop_bounds,
+																			drawn_level->x_tile_side_in_um,
+																			drawn_level->y_tile_side_in_um, image->origin_offset);
+					visible_tiles = clip_bounds2i(visible_tiles, crop_tile_bounds);
+				}
 
-			i32 missing_tiles_on_this_level = 0;
-			for (i32 tile_y = visible_tiles.min.y; tile_y < visible_tiles.max.y; ++tile_y) {
-				for (i32 tile_x = visible_tiles.min.x; tile_x < visible_tiles.max.x; ++tile_x) {
+				i32 missing_tiles_on_this_level = 0;
+				for (i32 tile_y = visible_tiles.min.y; tile_y < visible_tiles.max.y; ++tile_y) {
+					for (i32 tile_x = visible_tiles.min.x; tile_x < visible_tiles.max.x; ++tile_x) {
 
-					tile_t *tile = get_tile(drawn_level, tile_x, tile_y);
-					if (tile->texture) {
-						tile->time_last_drawn = app_state->frame_counter;
-						u32 texture = get_texture_for_tile(image, level, tile_x, tile_y);
+						tile_t *tile = get_tile(drawn_level, tile_x, tile_y);
+						if (tile->texture) {
+							tile->time_last_drawn = app_state->frame_counter;
+							u32 texture = get_texture_for_tile(image, level, tile_x, tile_y);
 
-						float tile_pos_x = drawn_level->origin_offset.x + drawn_level->x_tile_side_in_um * tile_x;
-						float tile_pos_y = drawn_level->origin_offset.y + drawn_level->y_tile_side_in_um * tile_y;
+							float tile_pos_x = drawn_level->origin_offset.x + drawn_level->x_tile_side_in_um * tile_x;
+							float tile_pos_y = drawn_level->origin_offset.y + drawn_level->y_tile_side_in_um * tile_y;
 
-						// define model matrix
-						mat4x4 model_matrix;
-						mat4x4_translate(model_matrix, tile_pos_x, tile_pos_y, 0.0f);
-						mat4x4_scale_aniso(model_matrix, model_matrix, drawn_level->x_tile_side_in_um,
-						                   drawn_level->y_tile_side_in_um, 1.0f);
-						glUniformMatrix4fv(basic_shader.u_model_matrix, 1, GL_FALSE, &model_matrix[0][0]);
+							// define model matrix
+							mat4x4 model_matrix;
+							mat4x4_translate(model_matrix, tile_pos_x, tile_pos_y, 0.0f);
+							mat4x4_scale_aniso(model_matrix, model_matrix, drawn_level->x_tile_side_in_um,
+											drawn_level->y_tile_side_in_um, 1.0f);
+							glUniformMatrix4fv(basic_shader.u_model_matrix, 1, GL_FALSE, &model_matrix[0][0]);
 
-						if (scene->draw_wsi_image) {
 							draw_rect(texture);
+
+						} else {
+							++missing_tiles_on_this_level;
 						}
-					} else {
-						++missing_tiles_on_this_level;
 					}
 				}
-			}
 
-			if (missing_tiles_on_this_level == 0) {
-				break; // don't need to bother drawing the next level, there are no gaps left to fill in!
-			}
+				if (missing_tiles_on_this_level == 0) {
+					break; // don't need to bother drawing the next level, there are no gaps left to fill in!
+				}
 
+			}
 		}
 
 		// restore OpenGL state
@@ -1782,20 +1824,16 @@ void viewer_update_and_render(app_state_t *app_state, input_t *input, i32 client
 		// Visualize the rectangles retreived from the 'valid data envelopes' (for debugging)
 		if (scene->draw_envelopes) {
 			image_t* image = app_state->loaded_images[0];
-			if (image->backend == IMAGE_BACKEND_ISYNTAX) {
-				isyntax_t* isyntax = &image->isyntax;
-				i32 rectangle_count = MIN(isyntax->valid_data_envelope_rectangle_count, COUNT(isyntax->valid_data_envelopes_rectangles));
-				for (i32 i = 0; i < rectangle_count; ++i) {
-					isyntax_valid_data_envelope_rectangle_t* rectangle = isyntax->valid_data_envelopes_rectangles + i;
-					temp_memory_t temp_memory = begin_temp_memory_on_local_thread();
-					v2f* points = arena_push_array(temp_memory.arena, 4, v2f);
-					points[0] = V2F(rectangle->topleft.x * isyntax->mpp_x, rectangle->topleft.y * isyntax->mpp_y);
-					points[1] = V2F(rectangle->topright.x * isyntax->mpp_x, rectangle->topright.y * isyntax->mpp_y);
-					points[2] = V2F(rectangle->bottomright.x * isyntax->mpp_x, rectangle->bottomright.y * isyntax->mpp_y);
-					points[3] = V2F(rectangle->bottomleft.x * isyntax->mpp_x, rectangle->bottomleft.y * isyntax->mpp_y);
-					gui_draw_polygon_outline_in_scene(points, 4, RGBA(255, 0, 0, 255), true, 3.0f, scene, NULL);
-					release_temp_memory(&temp_memory);
-				}
+			for (i32 i = 0; i < image->clip_rect_count; ++i) {
+				rect2f* rectangle = &image->clip_rects[i];
+				temp_memory_t temp_memory = begin_temp_memory_on_local_thread();
+				v2f* points = arena_push_array(temp_memory.arena, 4, v2f);
+				points[0] = V2F(rectangle->x, rectangle->y);
+				points[1] = V2F(rectangle->x + rectangle->w, rectangle->y);
+				points[2] = V2F(rectangle->x + rectangle->w, rectangle->y + rectangle->h);
+				points[3] = V2F(rectangle->x, rectangle->y + rectangle->h);
+				gui_draw_polygon_outline_in_scene(points, 4, RGBA(255, 0, 0, 255), true, 3.0f, scene, NULL);
+				release_temp_memory(&temp_memory);
 			}
 		}
 

--- a/src/core/viewer.cpp
+++ b/src/core/viewer.cpp
@@ -706,8 +706,7 @@ void update_and_render_image(app_state_t* app_state, image_t* image) {
 		}
 
 		if (scene->draw_wsi_background && image->clip_rect_count > 1){
-
-			// ToDo: de image width and height are not sufficient to contain all data both in iSyntax v1 and v2
+			// todo: the image width and height are not sufficient to contain all data both in iSyntax v1 and v2
 			// why are the width and heights this way / incorrect?
 			bounds2f stencil_bounds = {0, 0, image->width_in_um, image->height_in_um};
 			if (scene->is_cropped) {
@@ -1798,29 +1797,7 @@ void viewer_update_and_render(app_state_t *app_state, input_t *input, i32 client
 			}*/
 
 		}
-
-		// Visualize the 'valid data envelopes' encoded in iSyntax images (for debugging)
-		if (scene->draw_envelopes && false) {
-			image_t* image = app_state->loaded_images[0];
-			if (image->backend == IMAGE_BACKEND_ISYNTAX) {
-				isyntax_t* isyntax = &image->isyntax;
-				i32 envelope_count = MIN(isyntax->valid_data_envelope_count, COUNT(isyntax->valid_data_envelopes));
-				for (i32 i = 0; i < envelope_count; ++i) {
-					isyntax_valid_data_envelope_t* envelope = isyntax->valid_data_envelopes + i;
-					if (envelope->vertex_count > 1) {
-						temp_memory_t temp_memory = begin_temp_memory_on_local_thread();
-						v2f* points = arena_push_array(temp_memory.arena, envelope->vertex_count, v2f);
-						for (i32 j = 0; j < envelope->vertex_count; ++j) {
-							v2i v = envelope->vertices[j];
-							points[j] = V2F(v.x * isyntax->mpp_x, v.y * isyntax->mpp_y);
-						}
-						gui_draw_polygon_outline_in_scene(points, envelope->vertex_count, RGBA(255, 0, 0, 255), true, 3.0f, scene, NULL);
-						release_temp_memory(&temp_memory);
-					}
-				}
-			}
-		}
-		
+	
 		// Visualize the rectangles retreived from the 'valid data envelopes' (for debugging)
 		if (scene->draw_envelopes) {
 			image_t* image = app_state->loaded_images[0];

--- a/src/core/viewer.cpp
+++ b/src/core/viewer.cpp
@@ -692,7 +692,7 @@ void update_and_render_image(app_state_t* app_state, image_t* image) {
 
 				mat4x4 model_matrix;
 				mat4x4_translate(model_matrix,
-				                 image->origin_offset.x + label_image->world_pos.x - (label_image->width * label_image->mpp),
+				                 image->origin_offset.x + label_image->world_pos.x,
 				                 image->origin_offset.y + label_image->world_pos.y,
 				                 10.0f);
 				mat4x4_scale_aniso(model_matrix, model_matrix, pmax.x, pmax.y, 1.0f);
@@ -792,7 +792,9 @@ void update_and_render_image(app_state_t* app_state, image_t* image) {
 						                   drawn_level->y_tile_side_in_um, 1.0f);
 						glUniformMatrix4fv(basic_shader.u_model_matrix, 1, GL_FALSE, &model_matrix[0][0]);
 
-						draw_rect(texture);
+						if (scene->draw_wsi_image) {
+							draw_rect(texture);
+						}
 					} else {
 						++missing_tiles_on_this_level;
 					}

--- a/src/core/viewer.cpp
+++ b/src/core/viewer.cpp
@@ -1755,9 +1755,8 @@ void viewer_update_and_render(app_state_t *app_state, input_t *input, i32 client
 
 		}
 
-#if DO_DEBUG
 		// Visualize the 'valid data envelopes' encoded in iSyntax images (for debugging)
-		if (debug_draw_isyntax_valid_data_envelopes) {
+		if (scene->draw_envelopes) {
 			image_t* image = app_state->loaded_images[0];
 			if (image->backend == IMAGE_BACKEND_ISYNTAX) {
 				isyntax_t* isyntax = &image->isyntax;
@@ -1771,13 +1770,12 @@ void viewer_update_and_render(app_state_t *app_state, input_t *input, i32 client
 							v2i v = envelope->vertices[j];
 							points[j] = V2F(v.x * isyntax->mpp_x, v.y * isyntax->mpp_y);
 						}
-						gui_draw_polygon_outline_in_scene(points, envelope->vertex_count, RGBA(255, 0, 0, 255), true, 5.0f, scene, NULL);
+						gui_draw_polygon_outline_in_scene(points, envelope->vertex_count, RGBA(255, 0, 0, 255), true, 3.0f, scene, NULL);
 						release_temp_memory(&temp_memory);
 					}
 				}
 			}
 		}
-#endif
 
 		draw_grid(scene);
 //		i64 start = get_clock();

--- a/src/core/viewer.cpp
+++ b/src/core/viewer.cpp
@@ -663,8 +663,8 @@ void update_and_render_image(app_state_t* app_state, image_t* image) {
 
 //		last_section = profiler_end_section(last_section, "viewer_update_and_render: render (1)", 5.0f);
 
-		// Render label and macro images
-		if (draw_macro_image_in_background) {
+		// Render label and macro images // TZwi
+		if (scene->draw_macro_image) {
 			glDisable(GL_STENCIL_TEST);
 			if (macro_image->is_valid && macro_image->texture != 0) {
 				v2f pmax = {};
@@ -683,7 +683,7 @@ void update_and_render_image(app_state_t* app_state, image_t* image) {
 			}
 		}
 
-		if (draw_label_image_in_background) {
+		if (scene->draw_label_image) {
 			glDisable(GL_STENCIL_TEST);
 			if (label_image->is_valid && label_image->texture != 0 && macro_image->is_valid) {
 				v2f pmax = {};
@@ -692,12 +692,12 @@ void update_and_render_image(app_state_t* app_state, image_t* image) {
 
 				mat4x4 model_matrix;
 				mat4x4_translate(model_matrix,
-				                 image->origin_offset.x + label_image->world_pos.x,
+				                 image->origin_offset.x + label_image->world_pos.x - (label_image->width * label_image->mpp),
 				                 image->origin_offset.y + label_image->world_pos.y,
 				                 10.0f);
 				mat4x4_scale_aniso(model_matrix, model_matrix, pmax.x, pmax.y, 1.0f);
 				mat4x4 model_matrix_rot;
-				mat4x4_rotate_Z(model_matrix_rot, model_matrix, 0.5f * M_PI);
+				mat4x4_rotate_Z(model_matrix_rot, model_matrix, 0.0f * M_PI);
 				glUniformMatrix4fv(basic_shader.u_model_matrix, 1, GL_FALSE, &model_matrix_rot[0][0]);
 
 				draw_rect(label_image->texture);
@@ -742,7 +742,7 @@ void update_and_render_image(app_state_t* app_state, image_t* image) {
 
 		// If a background image has already been rendered, we need to blend the tiles on top
 		// while taking into account transparency.
-		if (draw_macro_image_in_background) {
+		if (scene->draw_macro_image) {
 			glEnable(GL_BLEND);
 			glBlendEquationSeparate(GL_FUNC_ADD, GL_FUNC_ADD);
 			glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ZERO);
@@ -1756,7 +1756,7 @@ void viewer_update_and_render(app_state_t *app_state, input_t *input, i32 client
 		}
 
 		// Visualize the 'valid data envelopes' encoded in iSyntax images (for debugging)
-		if (scene->draw_envelopes) {
+		if (scene->draw_envelopes && false) {
 			image_t* image = app_state->loaded_images[0];
 			if (image->backend == IMAGE_BACKEND_ISYNTAX) {
 				isyntax_t* isyntax = &image->isyntax;
@@ -1773,6 +1773,26 @@ void viewer_update_and_render(app_state_t *app_state, input_t *input, i32 client
 						gui_draw_polygon_outline_in_scene(points, envelope->vertex_count, RGBA(255, 0, 0, 255), true, 3.0f, scene, NULL);
 						release_temp_memory(&temp_memory);
 					}
+				}
+			}
+		}
+		
+		// Visualize the rectangles retreived from the 'valid data envelopes' (for debugging)
+		if (scene->draw_envelopes) {
+			image_t* image = app_state->loaded_images[0];
+			if (image->backend == IMAGE_BACKEND_ISYNTAX) {
+				isyntax_t* isyntax = &image->isyntax;
+				i32 rectangle_count = MIN(isyntax->valid_data_envelope_rectangle_count, COUNT(isyntax->valid_data_envelopes_rectangles));
+				for (i32 i = 0; i < rectangle_count; ++i) {
+					isyntax_valid_data_envelope_rectangle_t* rectangle = isyntax->valid_data_envelopes_rectangles + i;
+					temp_memory_t temp_memory = begin_temp_memory_on_local_thread();
+					v2f* points = arena_push_array(temp_memory.arena, 4, v2f);
+					points[0] = V2F(rectangle->topleft.x * isyntax->mpp_x, rectangle->topleft.y * isyntax->mpp_y);
+					points[1] = V2F(rectangle->topright.x * isyntax->mpp_x, rectangle->topright.y * isyntax->mpp_y);
+					points[2] = V2F(rectangle->bottomright.x * isyntax->mpp_x, rectangle->bottomright.y * isyntax->mpp_y);
+					points[3] = V2F(rectangle->bottomleft.x * isyntax->mpp_x, rectangle->bottomleft.y * isyntax->mpp_y);
+					gui_draw_polygon_outline_in_scene(points, 4, RGBA(255, 0, 0, 255), true, 3.0f, scene, NULL);
+					release_temp_memory(&temp_memory);
 				}
 			}
 		}

--- a/src/core/viewer.cpp
+++ b/src/core/viewer.cpp
@@ -663,7 +663,7 @@ void update_and_render_image(app_state_t* app_state, image_t* image) {
 
 //		last_section = profiler_end_section(last_section, "viewer_update_and_render: render (1)", 5.0f);
 
-		// Render label and macro images // TZwi
+		// Render label and macro images
 		if (scene->draw_macro_image) {
 			glDisable(GL_STENCIL_TEST);
 			if (macro_image->is_valid && macro_image->texture != 0) {

--- a/src/core/viewer.h
+++ b/src/core/viewer.h
@@ -265,6 +265,7 @@ typedef struct scene_t {
     bool draw_outlines;
     bool draw_envelopes;
 	bool draw_wsi_image;
+	bool draw_wsi_background;
 	bool draw_macro_image;
 	bool draw_label_image;
 	scale_bar_t scale_bar;

--- a/src/core/viewer.h
+++ b/src/core/viewer.h
@@ -263,6 +263,7 @@ typedef struct scene_t {
 	float transparent_tolerance;
 	bool use_transparent_filter;
     bool draw_outlines;
+    bool draw_envelopes;
 	scale_bar_t scale_bar;
 	bool is_mpp_known;
 	bool enable_grid;
@@ -467,8 +468,6 @@ extern i32 desired_window_width INIT(= 1280);
 extern i32 desired_window_height INIT(= 720);
 extern bool draw_macro_image_in_background INIT(= false);
 extern bool draw_label_image_in_background INIT(= false);
-extern bool debug_draw_isyntax_valid_data_envelopes INIT(= false);
-
 
 extern i32 global_next_resource_id INIT(= 1000);
 

--- a/src/core/viewer.h
+++ b/src/core/viewer.h
@@ -264,6 +264,7 @@ typedef struct scene_t {
 	bool use_transparent_filter;
     bool draw_outlines;
     bool draw_envelopes;
+	bool draw_wsi_image;
 	bool draw_macro_image;
 	bool draw_label_image;
 	scale_bar_t scale_bar;

--- a/src/core/viewer.h
+++ b/src/core/viewer.h
@@ -264,6 +264,8 @@ typedef struct scene_t {
 	bool use_transparent_filter;
     bool draw_outlines;
     bool draw_envelopes;
+	bool draw_macro_image;
+	bool draw_label_image;
 	scale_bar_t scale_bar;
 	bool is_mpp_known;
 	bool enable_grid;
@@ -463,11 +465,9 @@ extern bool use_fast_rendering INIT(= false); // optimize for performance for e.
 extern i32 global_lowest_scale_to_render INIT(= 0);
 extern i32 global_highest_scale_to_render INIT(= 16);
 
-extern bool window_start_maximized INIT(= true);
+extern bool window_start_maximized INIT(= false);
 extern i32 desired_window_width INIT(= 1280);
 extern i32 desired_window_height INIT(= 720);
-extern bool draw_macro_image_in_background INIT(= false);
-extern bool draw_label_image_in_background INIT(= false);
 
 extern i32 global_next_resource_id INIT(= 1000);
 

--- a/src/core/viewer_opengl.cpp
+++ b/src/core/viewer_opengl.cpp
@@ -380,5 +380,17 @@ void init_opengl_stuff(app_state_t* app_state) {
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST_MIPMAP_NEAREST);
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 1, 1, 0, GL_BGRA, GL_UNSIGNED_BYTE, &dummy_texture_color);
+	
+	u32 transparent_texture_color = MAKE_BGRA(255, 255, 255, 0);
+	transparent_texture = load_texture(&transparent_texture_color, 1, 1, GL_BGRA);
+
+	glBindTexture(GL_TEXTURE_2D, 0);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST_MIPMAP_NEAREST);
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 1, 1, 0, GL_BGRA, GL_UNSIGNED_BYTE, &transparent_texture_color);
 
 }

--- a/src/core/viewer_opengl.h
+++ b/src/core/viewer_opengl.h
@@ -91,6 +91,7 @@ extern basic_shader_t basic_shader;
 extern finalblit_shader_t finalblit_shader;
 
 extern u32 dummy_texture;
+extern u32 transparent_texture;
 
 extern bool finalize_textures_immediately INIT(= true);
 

--- a/src/isyntax/isyntax.c
+++ b/src/isyntax/isyntax.c
@@ -613,13 +613,14 @@ static bool isyntax_parse_scannedimage_child_node(isyntax_t* isyntax, u32 group,
 					strncpy(isyntax->image_dimension_unit, value, MIN(value_len, sizeof(isyntax->image_dimension_unit) - 1));
 					isyntax->image_dimension_unit[MIN(value_len, sizeof(isyntax->image_dimension_unit) - 1)] = '\0';				} break;
 				case 0x2007: /*UFS_IMAGE_DIMENSION_SCALE_FACTOR*/           {
+					// TZwi: in data model >= 100 the macro and label images have their own scaling factor
 					float mpp = atof(value);
 					if (isyntax->parser.dimension_index == 0 /*x*/) {
-						isyntax->mpp_x = mpp;
-						isyntax->is_mpp_known = true;
+						image->mpp_x = mpp;
+						image->is_mpp_known = true;
 					} else if (isyntax->parser.dimension_index == 1 /*y*/) {
-						isyntax->mpp_y = mpp;
-						isyntax->is_mpp_known = true;
+						image->mpp_y = mpp;
+						image->is_mpp_known = true;
 					}
 				} break;
 				case 0x2008: /*UFS_IMAGE_DIMENSION_DISCRETE_VALUES_STRING*/ {} break;
@@ -991,7 +992,15 @@ static bool isyntax_parse_scannedimage_child_node(isyntax_t* isyntax, u32 group,
 					}
 				} break; // data model >= 100
 				case 0x2026: /*UFS_IMAGE_VALID_ENVELOPE_DIMENSIONS*/ {} break; // data model >= 100
-				case 0x2027: /*UFS_IMAGE_DIMENSION_ORIGIN*/ {} break; // data model >= 100
+				case 0x2027: /*UFS_IMAGE_DIMENSION_ORIGIN*/ {  // data model >= 100
+					int origin = atoi(value);
+					if (isyntax->parser.dimension_index == 0 /*x*/) {
+						image->origin_x = origin;
+					} else if (isyntax->parser.dimension_index == 1 /*y*/) {
+						image->origin_y = origin;
+					}
+				} break;
+
 				case 0x2029: /*UFS_IMAGE_PIXEL_TRANSFORM_METHOD*/ {} break; // data model >= 100
 			}
 		} break;
@@ -3414,11 +3423,16 @@ bool isyntax_open(isyntax_t* isyntax, const char* filename, enum libisyntax_open
 					}
 				}
 			}
-
-			if (isyntax->mpp_x <= 0.0f || isyntax->mpp_y <= 0.0f) {
+			
+			isyntax_image_t* wsi_image = isyntax->images + isyntax->wsi_image_index;
+			if (wsi_image->mpp_x <= 0.0f || wsi_image->mpp_y <= 0.0f) {
 				isyntax->mpp_x = 1.0f; // should usually be 0.25; zero or below can never be right
 				isyntax->mpp_y = 1.0f;
 				isyntax->is_mpp_known = false;
+			}else{
+				isyntax->mpp_x = wsi_image->mpp_x;
+				isyntax->mpp_y = wsi_image->mpp_y;
+				isyntax->is_mpp_known = true;
 			}
 
 			isyntax->block_width = isyntax->block_header_templates[0].block_width;
@@ -3426,7 +3440,6 @@ bool isyntax_open(isyntax_t* isyntax, const char* filename, enum libisyntax_open
 			isyntax->tile_width = isyntax->block_width * 2; // tile dimension AFTER inverse wavelet transform
 			isyntax->tile_height = isyntax->block_height * 2;
 
-			isyntax_image_t* wsi_image = isyntax->images + isyntax->wsi_image_index;
 			if (wsi_image->image_type == ISYNTAX_IMAGE_TYPE_WSI) {
 
 				i32 block_width = isyntax->block_width;

--- a/src/isyntax/isyntax.c
+++ b/src/isyntax/isyntax.c
@@ -3796,7 +3796,7 @@ bool isyntax_open(isyntax_t* isyntax, const char* filename, enum libisyntax_open
 		}
 
 		if (success) {
-			isyntax_parse_envelopes(isyntax);
+			isyntax_envelopes_to_rectangles(isyntax);
 		}
 	}
 	return success;
@@ -3887,250 +3887,133 @@ void isyntax_destroy(isyntax_t* isyntax) {
 	file_handle_close(isyntax->file_handle);
 }
 
-void isyntax_parse_envelopes(isyntax_t* isyntax) {
-	// this script purely uses the data available in the envelope vertices; 
-	// it does a good job, but openings within an envelope can in certain cases cause
-	// some intersecting edges
-	// alternatively you could check the image data at each vertex, but that comes with
-	// the downside that the image data must be available before being able to parse
+// for qsort
+static int compare_vector_y (const void* a, const void* b) {
+	return (int)( ((v2i*)a)->y - ((v2i*)b)->y );
+}
+
+void isyntax_envelopes_to_rectangles(isyntax_t* isyntax){
+	// converts the valid data envelopes into an array of simple polygons
 
 	// iSyntax v1 does not contain envelopes, early return
 	if(isyntax->valid_data_envelope_count == 0){return;}
 
-	i32 envelope_count = MIN(isyntax->valid_data_envelope_count, COUNT(isyntax->valid_data_envelopes));
-		
-	// a single envelope can contains multiple non-continuous polygons, split and give them their own entree
-	isyntax_valid_data_envelope_t temp_envelopes[COUNT(isyntax->valid_data_envelopes)];
-	i32 temp_envelopes_count = 0;
-
 	bool error = false;
-	for (i32 i=0; i < envelope_count; ++i){
-		// check for valid vertex
+	for (i32 i=0; i < isyntax->valid_data_envelope_count; ++i) {
 		isyntax_valid_data_envelope_t* envelope = isyntax->valid_data_envelopes + i;
+		// invalid/empty envelope
 		if(envelope->vertex_count <= 1){continue;};
-		
-		// check for space in the envelope array
-		if(temp_envelopes_count >= COUNT(temp_envelopes)){
-			console_print("iSyntax: too many envelopes.");
-			error=true;
-			break;
-		}
 
-		// get envelope
-		temp_envelopes_count += 1;
-		isyntax_valid_data_envelope_t* temp_envelope = temp_envelopes + temp_envelopes_count -1;
-		i32 temp_envelope_index = 0;
+		// a rectangle contains 4 vertices, so worst case scenario you need 4x as much memory as rectangles.
+		// I think this is so unlikely we can reasonably keep a smaller footprint
+		v2i previous_vertices[COUNT(isyntax->valid_data_envelopes_rectangles)]; 
+		v2i next_vertices[COUNT(isyntax->valid_data_envelopes_rectangles)];
+		i32 previous_vertices_count = 0;
+		i32 next_vertices_count = 0;
 
-		// maintain list of vertices already used
-		u8 parsed[COUNT(temp_envelopes[0].vertices)] = {0};
-		
-		i32 start_index = 0;
-		
-		// current vector
-		i32 current_index = start_index;
-		v2i current_vector = envelope->vertices[current_index];
-		
-		// push first vertex
-		temp_envelope->vertices[temp_envelope_index] = current_vector;
-		//console_print("%d:%d,%d S", start_index, current_vector.x, current_vector.y);
+		i32 current_x = envelope->vertices[0].x;
+		i32 next_x = 0;
+		i32 iter_v = 0;
+		bool last_vertex = false;
 
-		i32 previous_movement = 3; // to_right = 1, to_left = 2, to_top = 3, to_bottom = 4
-		while(true){
-			i32 i_right = -1;
-			i32 i_left = -1;
-			i32 i_top = -1;
-			i32 i_bottom = -1;
-			i32 i_index = -1;
-			i32 to_right = 0x7ffffff;
-			i32 to_left = 0x7ffffff;
-			i32 to_top = 0x7ffffff;
-			i32 to_bottom = 0x7fffffff;
+		while (true) {
+			// get all vectors at specific x coordinate
+			next_vertices_count = 0;
+			while (true) {
+				if (iter_v >= envelope->vertex_count){
+					last_vertex = true;
+					break;
+				} else if (envelope->vertices[iter_v].x == current_x){
+					if (next_vertices_count >= COUNT(next_vertices)){
+						console_print("iSyntax: insufficient memory space to store all vertices of the valid data envelopes.");
+						error=true;
+						break;
+					}
+					next_vertices[next_vertices_count] = envelope->vertices[iter_v];
+					next_vertices_count += 1;
+					iter_v += 1;
+				} else {
+					next_x = envelope->vertices[iter_v].x;
+					break;
+				}
+			}
 
-			// out of bounds checking for safety
-			if(temp_envelope_index >= COUNT(parsed)){
-				console_print("iSyntax: infinite loop in envelope parsing.");
-				error = true;
+			
+			// no vertices to combine
+			if (previous_vertices_count == 0){
+				memcpy(previous_vertices, next_vertices, sizeof(previous_vertices));
+				previous_vertices_count = next_vertices_count;
+				current_x = next_x;
+				continue;
+			}
+
+			// build rectangles
+			if (previous_vertices_count % 2 != 0){
+				console_print("iSyntax: uneven vertices in envelope. Is this even possible?");
+				error=true;
 				break;
 			}
 
-			//find nearest neighbours
-			for(i32 j=0; j < envelope->vertex_count; ++j){
-				if(parsed[j] == 0){
-					v2i test_vector = envelope->vertices[j];
-					//console_print("t: %d:%d , %d:%d", current_vector.x, current_vector.y, test_vector.x, test_vector.y);
-					
-					if(current_vector.x == test_vector.x){
-						i32 y_diff = current_vector.y - test_vector.y;
-						if(y_diff > 0 && abs(y_diff) < to_top){
-							i_top = j;
-							to_top = abs(y_diff);
-						}else if(y_diff < 0 && abs(y_diff) < to_bottom){
-							i_bottom = j;
-							to_bottom = abs(y_diff);
-						}
-					}else if(current_vector.y == test_vector.y){
-						i32 x_diff = current_vector.x - test_vector.x;
-						if(x_diff > 0 && abs(x_diff) < to_left){
-							i_left = j;
-							to_left = abs(x_diff);
-						}else if(x_diff < 0 && abs(x_diff) < to_right){
-							i_right = j;
-							to_right = abs(x_diff);
-						}
-					}
-				}
-			}
-			// select best fitting neighbour, in principal nearest orthogonal neighbour
-			// if not available pick best alternative option
-			if(previous_movement == 1){ // to_right
-				if(i_top > -1 && i_bottom > -1){
-					if(to_top < to_bottom){
-						previous_movement = 3;
-						i_index = i_top;
-					}else if (to_bottom < to_top){
-						previous_movement = 4;
-						i_index = i_bottom;
-					}else{
-						previous_movement = 3;
-						i_index = i_top;
-					}
-				}else if(i_top > -1){
-					previous_movement = 3;
-					i_index = i_top;
-				}else if(i_bottom > -1){
-					previous_movement = 4;
-					i_index = i_bottom;
-				}else if(i_right > -1){
-					previous_movement = 1;
-					i_index = i_right;
-				}
-			}else if(previous_movement == 2){ // to_left
-				if(i_top > -1 && i_bottom > -1){
-					if(to_top < to_bottom){
-						previous_movement = 3;
-						i_index = i_top;
-					}else if (to_bottom < to_top){
-						previous_movement = 4;
-						i_index = i_bottom;
-					}else{
-						previous_movement = 3;
-						i_index = i_top;
-					}
-				}else if(i_top > -1){
-					previous_movement = 3;
-					i_index = i_top;
-				}else if(i_bottom > -1){
-					previous_movement = 4;
-					i_index = i_bottom;
-				}else if(i_left > -1){
-					previous_movement = 2;
-					i_index = i_left;
-				}
-			}else if(previous_movement == 3){ // to_top
-				if(i_left > -1 && i_right > -1){
-					if(i_left < i_right){
-						previous_movement = 2;
-						i_index = i_left;
-					}else if (i_left > i_right){
-						previous_movement = 1;
-						i_index = i_right;
-					}else{
-						previous_movement = 2;
-						i_index = i_left;
-					}
-				}else if(i_left > -1){
-					previous_movement = 2;
-					i_index = i_left;
-				}else if(i_right > -1){
-					previous_movement = 1;
-					i_index = i_right;
-				}else if(i_top > -1){
-					previous_movement = 3;
-					i_index = i_top;
-				}
-			}else if(previous_movement == 4){ // to_bottom
-				if(i_left > -1 && i_right > -1){
-					if (i_left > i_right){
-						previous_movement = 1;
-						i_index = i_right;
-					}else if(i_left < i_right){
-						previous_movement = 2;
-						i_index = i_left;
-					}else{
-						previous_movement = 1;
-						i_index = i_right;
-					}
-				}else if(i_right > -1){
-					previous_movement = 1;
-					i_index = i_right;
-				}else if(i_left > -1){
-					previous_movement = 2;
-					i_index = i_left;
-				}else if(i_bottom > -1){
-					previous_movement = 4;
-					i_index = i_bottom;
-				}
-			}
-
-			if(i_index == -1){
-				// cannot find neigbour; force envelope to close.
-				console_print("iSyntax: unclosable envelope.");
-				i_index = start_index;
-				error=true;
-			}
-
-			current_vector = envelope->vertices[i_index];
-			temp_envelope->vertices[temp_envelope_index+1] = current_vector;
-			temp_envelope_index += 1;
-			parsed[i_index] = 1; //
-			//console_print("%d:%d,%d", i_index, current_vector.x, current_vector.y);
-			
-			// check if previously added was the start vertex -> envelope done
-			if((current_vector.x == temp_envelope->vertices[0].x) && (current_vector.y == temp_envelope->vertices[0].y)){
-				// envelope done
-				temp_envelope->vertex_count = temp_envelope_index;
-				
-				// finalize reading mask
-				parsed[start_index] = 1;
-				
-				i32 counter = 0;
-				for (i32 j=0; j < COUNT(parsed); ++j){
-					counter += parsed[j];
-				}
-				
-				//console_print("Parsing done: %d [%d], vectors %d/%d", temp_envelopes_count -1, temp_envelope_index, counter, envelope->vertex_count);
-
-				// Find next start vertex
-				start_index = -1;
-				for (i32 j=0; j < envelope->vertex_count; ++j){
-					if (parsed[j] == 0){
-						start_index = j;
-						break;
-					}
-				}
-				// no vectors left, done with parsing
-				if(start_index == -1){
+			for (i32 j=0; j < previous_vertices_count; j += 2) {
+				if (isyntax->valid_data_envelope_rectangle_count >= COUNT(isyntax->valid_data_envelopes_rectangles)){
+					console_print("iSyntax: insufficient memory space to store all necessary rectangles of the valid data envelopes.");
+					error=true;
 					break;
 				}
 
-				current_index = start_index;
-				current_vector = envelope->vertices[current_index];
-				
-				// reset index first vertex
-				temp_envelopes_count += 1;
-				temp_envelope = temp_envelopes + temp_envelopes_count - 1;
-				temp_envelope_index = 0;
-				temp_envelope->vertices[temp_envelope_index] = current_vector;
-				previous_movement = 3;
-
-				//console_print("%d:%d,%d S", start_index, current_vector.x, current_vector.y);
+				isyntax_valid_data_envelope_rectangle_t rectangle;
+				rectangle.topleft = previous_vertices[j];
+				rectangle.bottomleft = previous_vertices[j+1];
+				rectangle.topright.x = current_x;
+				rectangle.topright.y = rectangle.topleft.y;
+				rectangle.bottomright.x = current_x;
+				rectangle.bottomright.y = rectangle.bottomleft.y;
+				isyntax->valid_data_envelopes_rectangles[isyntax->valid_data_envelope_rectangle_count] = rectangle;
+				isyntax->valid_data_envelope_rectangle_count += 1;
 			}
+
+			// identify and remove the overlapping vertexes, effectively: previous_vertices XOR next_vertices. 
+			// note: repeating vertices are theorically possible and shoulnt be removed for just being a duplicate
+			v2i temp_vertices[COUNT(isyntax->valid_data_envelopes_rectangles)];
+			i32 temp_vertices_count = 0;
+			bool passed_vertices[COUNT(isyntax->valid_data_envelopes_rectangles)] = {false};
+			for (i32 j=0; j < next_vertices_count; ++j) {
+				bool identified = false;
+				for (i32 k=0; k < previous_vertices_count; ++k) {
+					if ((previous_vertices[k].y == next_vertices[j].y) && (!passed_vertices[k])){
+						identified = true;
+						passed_vertices[k] = true;
+						break;
+					}
+				}
+				if (!identified){
+					temp_vertices[temp_vertices_count] = next_vertices[j];
+					temp_vertices_count += 1;
+				}
+			}
+			for (i32 j=0; j < previous_vertices_count; ++j) {
+				if(!passed_vertices[j]){
+					v2i temp_vertex;
+					temp_vertex.x = current_x;
+					temp_vertex.y = previous_vertices[j].y;
+					temp_vertices[temp_vertices_count] = temp_vertex;
+					temp_vertices_count += 1;
+				}
+			}
+			
+			// sort from low-to-highest y value
+			// when sorted two sequential vertices will form one edge of a rectangle
+			qsort(temp_vertices, temp_vertices_count, sizeof(temp_vertices[0]), compare_vector_y);
+			memcpy(previous_vertices, temp_vertices, sizeof(previous_vertices));
+			previous_vertices_count = temp_vertices_count;
+
+			// nothing left to parse
+			if (last_vertex || error) {
+				break;
+			}
+
+			// instantiate next step
+			current_x = next_x;
 		}
-	}
-	// copy the temporary over the old data
-	if(!error){
-		ASSERT(sizeof(temp_envelopes) == sizeof(isyntax->valid_data_envelopes));
-		memcpy(isyntax->valid_data_envelopes, temp_envelopes, sizeof(isyntax->valid_data_envelopes));
-		isyntax->valid_data_envelope_count = temp_envelopes_count;
 	}
 }

--- a/src/isyntax/isyntax.c
+++ b/src/isyntax/isyntax.c
@@ -3809,7 +3809,7 @@ bool isyntax_open(isyntax_t* isyntax, const char* filename, enum libisyntax_open
 		}
 
 		if (success) {
-			isyntax_envelopes_to_rectangles(isyntax);
+			isyntax_envelopes_to_rect(isyntax);
 		}
 	}
 	return success;
@@ -3905,11 +3905,24 @@ static int compare_vector_y (const void* a, const void* b) {
 	return (int)( ((v2i*)a)->y - ((v2i*)b)->y );
 }
 
-void isyntax_envelopes_to_rectangles(isyntax_t* isyntax){
+void isyntax_envelopes_to_rect(isyntax_t* isyntax){
 	// converts the valid data envelopes into an array of simple polygons
 
-	// iSyntax v1 does not contain envelopes, early return
-	if(isyntax->valid_data_envelope_count == 0){return;}
+	// iSyntax v1 does not contain envelopes, construct dummy envelope
+	if(isyntax->valid_data_envelope_count == 0 && isyntax->image_count > 0){
+		// Can i assume a WSI image exists? Even if not, I think it defaults iniatializes to 0...
+		isyntax_image_t* wsi_image = isyntax->images + isyntax->wsi_image_index;
+
+		rect2i rectangle;
+		rectangle.x = 0;
+		rectangle.y = 0;
+		rectangle.h = wsi_image->height;
+		rectangle.w = wsi_image->width;
+		
+		isyntax->valid_data_envelopes_rectangles[isyntax->valid_data_envelope_rectangle_count] = rectangle;
+		isyntax->valid_data_envelope_rectangle_count += 1;
+		return;
+	}
 
 	bool error = false;
 	for (i32 i=0; i < isyntax->valid_data_envelope_count; ++i) {
@@ -3974,13 +3987,12 @@ void isyntax_envelopes_to_rectangles(isyntax_t* isyntax){
 					break;
 				}
 
-				isyntax_valid_data_envelope_rectangle_t rectangle;
-				rectangle.topleft = previous_vertices[j];
-				rectangle.bottomleft = previous_vertices[j+1];
-				rectangle.topright.x = current_x;
-				rectangle.topright.y = rectangle.topleft.y;
-				rectangle.bottomright.x = current_x;
-				rectangle.bottomright.y = rectangle.bottomleft.y;
+				rect2i rectangle;
+				rectangle.x = previous_vertices[j].x;
+				rectangle.y = previous_vertices[j].y;
+				rectangle.h = previous_vertices[j+1].y - previous_vertices[j].y;
+				rectangle.w = current_x - previous_vertices[j].x;
+
 				isyntax->valid_data_envelopes_rectangles[isyntax->valid_data_envelope_rectangle_count] = rectangle;
 				isyntax->valid_data_envelope_rectangle_count += 1;
 			}

--- a/src/isyntax/isyntax.c
+++ b/src/isyntax/isyntax.c
@@ -986,6 +986,7 @@ static bool isyntax_parse_scannedimage_child_node(isyntax_t* isyntax, u32 group,
 							envelope->vertices[envelope->vertex_count++] = vertex;
 						} else {
 							success = false; // out of bounds
+							console_print("Warning: cannot read all UFS_IMAGE_OPP_EXTREME_VERTEX (out of bounds)\n");
 						}
 					}
 				} break; // data model >= 100
@@ -1623,23 +1624,72 @@ static u32 wavelet_coefficient_to_color_value(icoeff_t coefficient) {
 }
 #endif
 
-static rgba_t ycocg_to_rgb(icoeff_t Y, icoeff_t Co, icoeff_t Cg) {
+static rgba_t ycocg_to_rgb_v1(icoeff_t Y, icoeff_t Co, icoeff_t Cg) {
     icoeff_t tmp = Y - Cg/2;
     icoeff_t G = tmp + Cg;
     icoeff_t B = tmp - Co/2;
     icoeff_t R = B + Co;
+
+	B = (B < 0 ? 0 : B);
+	G = (G < 0 ? 0 : G);
+	R = (R < 0 ? 0 : R);
+
     return (rgba_t){{{ATMOST(255, R), ATMOST(255, G), ATMOST(255, B), 255}}};
 }
 
-static rgba_t ycocg_to_bgr(icoeff_t Y, icoeff_t Co, icoeff_t Cg) {
+static rgba_t ycocg_to_bgr_v1(icoeff_t Y, icoeff_t Co, icoeff_t Cg) {
     icoeff_t tmp = Y - Cg/2;
     icoeff_t G = tmp + Cg;
     icoeff_t B = tmp - Co/2;
     icoeff_t R = B + Co;
+
+	B = (B < 0 ? 0 : B);
+	G = (G < 0 ? 0 : G);
+	R = (R < 0 ? 0 : R);
+
     return (rgba_t){{{ATMOST(255, B), ATMOST(255, G), ATMOST(255, R), 255}}};
 }
 
-static void convert_ycocg_to_bgra_block(icoeff_t* Y, icoeff_t* Co, icoeff_t* Cg, i32 width, i32 height, i32 stride, u32* out_bgra) {
+static rgba_t ycocg_to_rgb_v2(icoeff_t Y, icoeff_t Co, icoeff_t Cg) {
+    icoeff_t tmp = Y - Cg/2;
+    icoeff_t G = tmp + Cg;
+    icoeff_t B = tmp - Co/2;
+    icoeff_t R = B + Co;
+
+	G = G >> 1;
+	B = B >> 1;
+	R = R >> 1;
+
+	B = (B < 0 ? 0 : B);
+	G = (G < 0 ? 0 : G);
+	R = (R < 0 ? 0 : R);
+
+    return (rgba_t){{{ATMOST(255, R), ATMOST(255, G), ATMOST(255, B), 255}}};
+}
+
+static rgba_t ycocg_to_bgr_v2(icoeff_t Y, icoeff_t Co, icoeff_t Cg) {
+    icoeff_t tmp = Y - Cg/2;
+    icoeff_t G = tmp + Cg;
+    icoeff_t B = tmp - Co/2;
+    icoeff_t R = B + Co;
+	
+	// iSyntax v2 measures the YCoCg data in a 9 bit resolution, compared to iSyntax v1 8 bit resolution (both stored as 16 bit integers)
+	// so we need to halve the resolution by bitshifting
+	B = B >> 1;
+	G = G >> 1;
+	R = R >> 1;
+
+	// sometimes, especially in lower magnifications the YCoCg -> RGB conversion leads to invalid negative color values (I guess the wavelet transform is not 100% correct)
+	// these values are small but when casting to u8 become significant (-2 -> 255 + -2 = 253)
+	// the SIMD _mm_packus_epi16 uses a unsignedsaturate that doesnt have this behavior (<0 -> 0), copy this behavior:
+	B = (B < 0 ? 0 : B);
+	G = (G < 0 ? 0 : G);
+	R = (R < 0 ? 0 : R);
+	
+    return (rgba_t){{{ATMOST(255, B), ATMOST(255, G), ATMOST(255, R), 255}}};
+}
+
+static void convert_ycocg_to_bgra_block_v1(icoeff_t* Y, icoeff_t* Co, icoeff_t* Cg, i32 width, i32 height, i32 stride, u32* out_bgra) {
     i32 aligned_width = (width / 8) * 8;
 
 	for (i32 y = 0; y < height; ++y) {
@@ -1700,7 +1750,7 @@ static void convert_ycocg_to_bgra_block(icoeff_t* Y, icoeff_t* Co, icoeff_t* Cg,
 #endif
         // Slow version, for last unaligned elements or in case SIMD isn't available
 		for (; i < width; ++i) {
-			((rgba_t*)dest)[i] = ycocg_to_bgr(Y[i], Co[i], Cg[i]);
+			((rgba_t*)dest)[i] = ycocg_to_bgr_v1(Y[i], Co[i], Cg[i]);
 		}
 
 		Y += stride;
@@ -1709,7 +1759,7 @@ static void convert_ycocg_to_bgra_block(icoeff_t* Y, icoeff_t* Co, icoeff_t* Cg,
 	}
 }
 
-static void convert_ycocg_to_rgba_block(icoeff_t* Y, icoeff_t* Co, icoeff_t* Cg, i32 width, i32 height, i32 stride, u32* out_rgba) {
+static void convert_ycocg_to_rgba_block_v1(icoeff_t* Y, icoeff_t* Co, icoeff_t* Cg, i32 width, i32 height, i32 stride, u32* out_rgba) {
     i32 aligned_width = (width / 8) * 8;
 
     for (i32 y = 0; y < height; ++y) {
@@ -1770,7 +1820,156 @@ static void convert_ycocg_to_rgba_block(icoeff_t* Y, icoeff_t* Co, icoeff_t* Cg,
 #endif
         // Slow version, for last unaligned elements or in case SIMD isn't available
         for (; i < width; ++i) {
-            ((rgba_t*)dest)[i] = ycocg_to_rgb(Y[i], Co[i], Cg[i]);
+            ((rgba_t*)dest)[i] = ycocg_to_rgb_v1(Y[i], Co[i], Cg[i]);
+        }
+
+        Y += stride;
+        Co += stride;
+        Cg += stride;
+    }
+}
+
+static void convert_ycocg_to_bgra_block_v2(icoeff_t* Y, icoeff_t* Co, icoeff_t* Cg, i32 width, i32 height, i32 stride, u32* out_bgra) {
+    i32 aligned_width = (width / 8) * 8;
+
+	for (i32 y = 0; y < height; ++y) {
+		u32* dest = out_bgra + (y * width);
+        i32 i = 0;
+#if defined(__SSE2__) && defined(__SSSE3__)
+		//console_print_error("v2 - SIMD");
+		// Fast SIMD version (2x faster on my system)
+		for (; i < aligned_width; i += 8) {
+			// Do the color space conversion
+			__m128i Y_ = _mm_loadu_si128((__m128i*)(Y + i));
+			__m128i Co_ = _mm_loadu_si128((__m128i*)(Co + i));
+			__m128i Cg_ = _mm_loadu_si128((__m128i*)(Cg + i));
+			__m128i tmp = _mm_sub_epi16(Y_, _mm_srai_epi16(Cg_, 1)); // tmp = Y - Cg/2
+			__m128i G = _mm_add_epi16(tmp, Cg_);                     // G = tmp + Cg
+			__m128i B = _mm_sub_epi16(tmp, _mm_srai_epi16(Co_, 1));  // B = tmp - Co/2
+			__m128i R = _mm_add_epi16(B, Co_);                       // R = B + Co
+
+			// Bit shift from 9bit to 8bit
+			R = _mm_srai_epi16(R, 1);
+			G = _mm_srai_epi16(G, 1);
+			B = _mm_srai_epi16(B, 1);
+
+			// Shuffle and clamp
+			__m128i A = _mm_set1_epi16(0x7fff);
+			__m128i BG = _mm_packus_epi16(B, G); //BBBBBBBB + GGGGGGGG -> BBBBGGGG
+			__m128i RA = _mm_packus_epi16(R, A); //RRRRRRRR + AAAAAAAA -> RRRRAAAA
+
+			__m128i v_perm = _mm_setr_epi8(0, 8, 1, 9, 2, 10, 3, 11, 4, 12, 5, 13, 6, 14, 7, 15);
+			BG = _mm_shuffle_epi8(BG, v_perm); // BGBGBGBG
+			RA = _mm_shuffle_epi8(RA, v_perm); // RARARARA
+			__m128i lo = _mm_unpacklo_epi16(BG, RA); // BGRA
+			__m128i hi = _mm_unpackhi_epi16(BG, RA);
+
+			_mm_storeu_si128((__m128i*)(dest + i), lo);
+			_mm_storeu_si128((__m128i*)(dest + i + 4), hi);
+		}
+#elif defined(__ARM_NEON__)
+        // Fast SIMD version for ARM NEON
+        for (; i < aligned_width; i += 8) {
+            int16x8_t Y_ = vld1q_s16(Y + i);
+            int16x8_t Co_ = vld1q_s16(Co + i);
+            int16x8_t Cg_ = vld1q_s16(Cg + i);
+            int16x8_t tmp = vsubq_s16(Y_, vshrq_n_s16(Cg_, 1));
+            int16x8_t G = vaddq_s16(tmp, Cg_);
+            int16x8_t B = vsubq_s16(tmp, vshrq_n_s16(Co_, 1));
+            int16x8_t R = vaddq_s16(B, Co_);
+
+			// Please check this, i am not in the capacity to debug arm neon.
+			G = vshrq_n_s16(G, 1);
+			B = vshrq_n_s16(B, 1);
+			R = vshrq_n_s16(R, 1);
+
+            uint8x8x4_t bgra_vec;
+            bgra_vec.val[2] = vqmovun_s16(R);
+            bgra_vec.val[1] = vqmovun_s16(G);
+            bgra_vec.val[0] = vqmovun_s16(B);
+            bgra_vec.val[3] = vdup_n_u8(0xFF);
+
+            vst4_u8((uint8_t*)(dest + i), bgra_vec);
+        }
+#endif
+        // Slow version, for last unaligned elements or in case SIMD isn't available
+		for (; i < width; ++i) {
+			((rgba_t*)dest)[i] = ycocg_to_bgr_v2(Y[i], Co[i], Cg[i]);
+		}
+
+		Y += stride;
+		Co += stride;
+		Cg += stride;
+	}
+
+	//console_print("%d %d %d %d", out_bgra[0], out_bgra[1], out_bgra[2], out_bgra[3]);
+}
+
+static void convert_ycocg_to_rgba_block_v2(icoeff_t* Y, icoeff_t* Co, icoeff_t* Cg, i32 width, i32 height, i32 stride, u32* out_rgba) {
+    i32 aligned_width = (width / 8) * 8;
+
+    for (i32 y = 0; y < height; ++y) {
+        u32* dest = out_rgba + (y * width);
+        i32 i = 0;
+#if defined(__SSE2__) && defined(__SSSE3__)
+        // Fast SIMD version (~2x faster on my system)
+		for (; i < aligned_width; i += 8) {
+			// Do the color space conversion
+			__m128i Y_ = _mm_loadu_si128((__m128i*)(Y + i));
+			__m128i Co_ = _mm_loadu_si128((__m128i*)(Co + i));
+			__m128i Cg_ = _mm_loadu_si128((__m128i*)(Cg + i));
+			__m128i tmp = _mm_sub_epi16(Y_, _mm_srai_epi16(Cg_, 1)); // tmp = Y - Cg/2
+			__m128i G = _mm_add_epi16(tmp, Cg_);                     // G = tmp + Cg
+			__m128i B = _mm_sub_epi16(tmp, _mm_srai_epi16(Co_, 1));  // B = tmp - Co/2
+			__m128i R = _mm_add_epi16(B, Co_);                       // R = B + Co
+
+			// Bit shift from 9bit to 8bit
+			R = _mm_srai_epi16(R, 1);
+			G = _mm_srai_epi16(G, 1);
+			B = _mm_srai_epi16(B, 1);
+
+			// Shuffle and clamp
+			__m128i A = _mm_set1_epi16(0x7fff);
+			__m128i RG = _mm_packus_epi16(R, G); //RRRRRRRR + GGGGGGGG -> RRRRGGGG
+			__m128i BA = _mm_packus_epi16(B, A); //BBBBBBBB + AAAAAAAA -> BBBBAAAA
+
+			__m128i v_perm = _mm_setr_epi8(0, 8, 1, 9, 2, 10, 3, 11, 4, 12, 5, 13, 6, 14, 7, 15);
+			RG = _mm_shuffle_epi8(RG, v_perm); // RGRGRGRG
+			BA = _mm_shuffle_epi8(BA, v_perm); // BABABABA
+			__m128i lo = _mm_unpacklo_epi16(RG, BA); // RGBA
+			__m128i hi = _mm_unpackhi_epi16(RG, BA);
+
+			_mm_storeu_si128((__m128i*)(dest + i), lo);
+			_mm_storeu_si128((__m128i*)(dest + i + 4), hi);
+		}
+#elif defined(__ARM_NEON__)
+        // Fast SIMD version for ARM NEON
+        for (; i < aligned_width; i += 8) {
+            int16x8_t Y_ = vld1q_s16(Y + i);
+            int16x8_t Co_ = vld1q_s16(Co + i);
+            int16x8_t Cg_ = vld1q_s16(Cg + i);
+            int16x8_t tmp = vsubq_s16(Y_, vshrq_n_s16(Cg_, 1));
+            int16x8_t G = vaddq_s16(tmp, Cg_);
+            int16x8_t B = vsubq_s16(tmp, vshrq_n_s16(Co_, 1));
+            int16x8_t R = vaddq_s16(B, Co_);
+
+			// Please check this, i am not in the capacity to debug arm neon.
+			R = vshrq_n_s16(R, 1);
+			G = vshrq_n_s16(G, 1);
+			B = vshrq_n_s16(B, 1);
+
+            uint8x8x4_t rgba_vec;
+            rgba_vec.val[0] = vqmovun_s16(R);
+            rgba_vec.val[1] = vqmovun_s16(G);
+            rgba_vec.val[2] = vqmovun_s16(B);
+            rgba_vec.val[3] = vdup_n_u8(0xFF);
+
+            vst4_u8((uint8_t*)(dest + i), rgba_vec);
+        }
+#endif
+        // Slow version, for last unaligned elements or in case SIMD isn't available
+        for (; i < width; ++i) {
+            ((rgba_t*)dest)[i] = ycocg_to_rgb_v2(Y[i], Co[i], Cg[i]);
         }
 
         Y += stride;
@@ -1859,8 +2058,6 @@ static inline void get_offsetted_coeff_blocks(icoeff_t** ll_hl_lh_hh, i32 offset
 	}
 
 }
-
-
 
 u32 isyntax_get_adjacent_tiles_mask(isyntax_level_t* level, i32 tile_x, i32 tile_y) {
 	ASSERT(tile_x >= 0 && tile_y >= 0);
@@ -2367,21 +2564,40 @@ void isyntax_load_tile(isyntax_t* isyntax, isyntax_image_t* wsi, i32 scale, i32 
 	i32 tile_height = block_height * 2;
 
 	i32 valid_offset = (first_valid_pixel * idwt_stride) + first_valid_pixel;
-    switch (pixel_format) {
-        case LIBISYNTAX_PIXEL_FORMAT_BGRA:
-            convert_ycocg_to_bgra_block(Y + valid_offset, Co + valid_offset, Cg + valid_offset, tile_width, tile_height,
-                                        idwt_stride, out_buffer_or_null);
-            break;
 
-        case LIBISYNTAX_PIXEL_FORMAT_RGBA:
-            convert_ycocg_to_rgba_block(Y + valid_offset, Co + valid_offset, Cg + valid_offset, tile_width, tile_height,
-                                        idwt_stride, out_buffer_or_null);
-            break;
+	if(isyntax->data_model_major_version < 100){ // iSyntax v1
+		switch (pixel_format) {
+			case LIBISYNTAX_PIXEL_FORMAT_BGRA:
+				convert_ycocg_to_bgra_block_v1(Y + valid_offset, Co + valid_offset, Cg + valid_offset, tile_width, tile_height,
+											idwt_stride, out_buffer_or_null);
+				break;
 
-        default:
-            ASSERT(!"unknown pixel format!");
-            break;
-    }
+			case LIBISYNTAX_PIXEL_FORMAT_RGBA:
+				convert_ycocg_to_rgba_block_v1(Y + valid_offset, Co + valid_offset, Cg + valid_offset, tile_width, tile_height,
+											idwt_stride, out_buffer_or_null);
+				break;
+
+			default:
+				ASSERT(!"unknown pixel format!");
+				break;
+		}
+	}else{ // iSyntax v2
+		switch (pixel_format) {
+			case LIBISYNTAX_PIXEL_FORMAT_BGRA:
+				convert_ycocg_to_bgra_block_v2(Y + valid_offset, Co + valid_offset, Cg + valid_offset, tile_width, tile_height,
+											idwt_stride, out_buffer_or_null);
+				break;
+
+			case LIBISYNTAX_PIXEL_FORMAT_RGBA:
+				convert_ycocg_to_rgba_block_v2(Y + valid_offset, Co + valid_offset, Cg + valid_offset, tile_width, tile_height,
+											idwt_stride, out_buffer_or_null);
+				break;
+
+			default:
+				ASSERT(!"unknown pixel format!");
+				break;
+		}
+	}
 	isyntax->total_rgb_transform_time += get_seconds_elapsed(start, get_clock());
 
 	//		float elapsed_rgb = get_seconds_elapsed(start, get_clock());
@@ -3578,6 +3794,10 @@ bool isyntax_open(isyntax_t* isyntax, const char* filename, enum libisyntax_open
 				success = false;
 			}
 		}
+
+		if (success) {
+			isyntax_parse_envelopes(isyntax);
+		}
 	}
 	return success;
 }
@@ -3665,4 +3885,252 @@ void isyntax_destroy(isyntax_t* isyntax) {
 		libisyntax_cache_destroy(isyntax->cache);
 	}
 	file_handle_close(isyntax->file_handle);
+}
+
+void isyntax_parse_envelopes(isyntax_t* isyntax) {
+	// this script purely uses the data available in the envelope vertices; 
+	// it does a good job, but openings within an envelope can in certain cases cause
+	// some intersecting edges
+	// alternatively you could check the image data at each vertex, but that comes with
+	// the downside that the image data must be available before being able to parse
+
+	// iSyntax v1 does not contain envelopes, early return
+	if(isyntax->valid_data_envelope_count == 0){return;}
+
+	i32 envelope_count = MIN(isyntax->valid_data_envelope_count, COUNT(isyntax->valid_data_envelopes));
+		
+	// a single envelope can contains multiple non-continuous polygons, split and give them their own entree
+	isyntax_valid_data_envelope_t temp_envelopes[COUNT(isyntax->valid_data_envelopes)];
+	i32 temp_envelopes_count = 0;
+
+	bool error = false;
+	for (i32 i=0; i < envelope_count; ++i){
+		// check for valid vertex
+		isyntax_valid_data_envelope_t* envelope = isyntax->valid_data_envelopes + i;
+		if(envelope->vertex_count <= 1){continue;};
+		
+		// check for space in the envelope array
+		if(temp_envelopes_count >= COUNT(temp_envelopes)){
+			console_print("iSyntax: too many envelopes.");
+			error=true;
+			break;
+		}
+
+		// get envelope
+		temp_envelopes_count += 1;
+		isyntax_valid_data_envelope_t* temp_envelope = temp_envelopes + temp_envelopes_count -1;
+		i32 temp_envelope_index = 0;
+
+		// maintain list of vertices already used
+		u8 parsed[COUNT(temp_envelopes[0].vertices)] = {0};
+		
+		i32 start_index = 0;
+		
+		// current vector
+		i32 current_index = start_index;
+		v2i current_vector = envelope->vertices[current_index];
+		
+		// push first vertex
+		temp_envelope->vertices[temp_envelope_index] = current_vector;
+		//console_print("%d:%d,%d S", start_index, current_vector.x, current_vector.y);
+
+		i32 previous_movement = 3; // to_right = 1, to_left = 2, to_top = 3, to_bottom = 4
+		while(true){
+			i32 i_right = -1;
+			i32 i_left = -1;
+			i32 i_top = -1;
+			i32 i_bottom = -1;
+			i32 i_index = -1;
+			i32 to_right = 0x7ffffff;
+			i32 to_left = 0x7ffffff;
+			i32 to_top = 0x7ffffff;
+			i32 to_bottom = 0x7fffffff;
+
+			// out of bounds checking for safety
+			if(temp_envelope_index >= COUNT(parsed)){
+				console_print("iSyntax: infinite loop in envelope parsing.");
+				error = true;
+				break;
+			}
+
+			//find nearest neighbours
+			for(i32 j=0; j < envelope->vertex_count; ++j){
+				if(parsed[j] == 0){
+					v2i test_vector = envelope->vertices[j];
+					//console_print("t: %d:%d , %d:%d", current_vector.x, current_vector.y, test_vector.x, test_vector.y);
+					
+					if(current_vector.x == test_vector.x){
+						i32 y_diff = current_vector.y - test_vector.y;
+						if(y_diff > 0 && abs(y_diff) < to_top){
+							i_top = j;
+							to_top = abs(y_diff);
+						}else if(y_diff < 0 && abs(y_diff) < to_bottom){
+							i_bottom = j;
+							to_bottom = abs(y_diff);
+						}
+					}else if(current_vector.y == test_vector.y){
+						i32 x_diff = current_vector.x - test_vector.x;
+						if(x_diff > 0 && abs(x_diff) < to_left){
+							i_left = j;
+							to_left = abs(x_diff);
+						}else if(x_diff < 0 && abs(x_diff) < to_right){
+							i_right = j;
+							to_right = abs(x_diff);
+						}
+					}
+				}
+			}
+			// select best fitting neighbour, in principal nearest orthogonal neighbour
+			// if not available pick best alternative option
+			if(previous_movement == 1){ // to_right
+				if(i_top > -1 && i_bottom > -1){
+					if(to_top < to_bottom){
+						previous_movement = 3;
+						i_index = i_top;
+					}else if (to_bottom < to_top){
+						previous_movement = 4;
+						i_index = i_bottom;
+					}else{
+						previous_movement = 3;
+						i_index = i_top;
+					}
+				}else if(i_top > -1){
+					previous_movement = 3;
+					i_index = i_top;
+				}else if(i_bottom > -1){
+					previous_movement = 4;
+					i_index = i_bottom;
+				}else if(i_right > -1){
+					previous_movement = 1;
+					i_index = i_right;
+				}
+			}else if(previous_movement == 2){ // to_left
+				if(i_top > -1 && i_bottom > -1){
+					if(to_top < to_bottom){
+						previous_movement = 3;
+						i_index = i_top;
+					}else if (to_bottom < to_top){
+						previous_movement = 4;
+						i_index = i_bottom;
+					}else{
+						previous_movement = 3;
+						i_index = i_top;
+					}
+				}else if(i_top > -1){
+					previous_movement = 3;
+					i_index = i_top;
+				}else if(i_bottom > -1){
+					previous_movement = 4;
+					i_index = i_bottom;
+				}else if(i_left > -1){
+					previous_movement = 2;
+					i_index = i_left;
+				}
+			}else if(previous_movement == 3){ // to_top
+				if(i_left > -1 && i_right > -1){
+					if(i_left < i_right){
+						previous_movement = 2;
+						i_index = i_left;
+					}else if (i_left > i_right){
+						previous_movement = 1;
+						i_index = i_right;
+					}else{
+						previous_movement = 2;
+						i_index = i_left;
+					}
+				}else if(i_left > -1){
+					previous_movement = 2;
+					i_index = i_left;
+				}else if(i_right > -1){
+					previous_movement = 1;
+					i_index = i_right;
+				}else if(i_top > -1){
+					previous_movement = 3;
+					i_index = i_top;
+				}
+			}else if(previous_movement == 4){ // to_bottom
+				if(i_left > -1 && i_right > -1){
+					if (i_left > i_right){
+						previous_movement = 1;
+						i_index = i_right;
+					}else if(i_left < i_right){
+						previous_movement = 2;
+						i_index = i_left;
+					}else{
+						previous_movement = 1;
+						i_index = i_right;
+					}
+				}else if(i_right > -1){
+					previous_movement = 1;
+					i_index = i_right;
+				}else if(i_left > -1){
+					previous_movement = 2;
+					i_index = i_left;
+				}else if(i_bottom > -1){
+					previous_movement = 4;
+					i_index = i_bottom;
+				}
+			}
+
+			if(i_index == -1){
+				// cannot find neigbour; force envelope to close.
+				console_print("iSyntax: unclosable envelope.");
+				i_index = start_index;
+				error=true;
+			}
+
+			current_vector = envelope->vertices[i_index];
+			temp_envelope->vertices[temp_envelope_index+1] = current_vector;
+			temp_envelope_index += 1;
+			parsed[i_index] = 1; //
+			//console_print("%d:%d,%d", i_index, current_vector.x, current_vector.y);
+			
+			// check if previously added was the start vertex -> envelope done
+			if((current_vector.x == temp_envelope->vertices[0].x) && (current_vector.y == temp_envelope->vertices[0].y)){
+				// envelope done
+				temp_envelope->vertex_count = temp_envelope_index;
+				
+				// finalize reading mask
+				parsed[start_index] = 1;
+				
+				i32 counter = 0;
+				for (i32 j=0; j < COUNT(parsed); ++j){
+					counter += parsed[j];
+				}
+				
+				//console_print("Parsing done: %d [%d], vectors %d/%d", temp_envelopes_count -1, temp_envelope_index, counter, envelope->vertex_count);
+
+				// Find next start vertex
+				start_index = -1;
+				for (i32 j=0; j < envelope->vertex_count; ++j){
+					if (parsed[j] == 0){
+						start_index = j;
+						break;
+					}
+				}
+				// no vectors left, done with parsing
+				if(start_index == -1){
+					break;
+				}
+
+				current_index = start_index;
+				current_vector = envelope->vertices[current_index];
+				
+				// reset index first vertex
+				temp_envelopes_count += 1;
+				temp_envelope = temp_envelopes + temp_envelopes_count - 1;
+				temp_envelope_index = 0;
+				temp_envelope->vertices[temp_envelope_index] = current_vector;
+				previous_movement = 3;
+
+				//console_print("%d:%d,%d S", start_index, current_vector.x, current_vector.y);
+			}
+		}
+	}
+	// copy the temporary over the old data
+	if(!error){
+		ASSERT(sizeof(temp_envelopes) == sizeof(isyntax->valid_data_envelopes));
+		memcpy(isyntax->valid_data_envelopes, temp_envelopes, sizeof(isyntax->valid_data_envelopes));
+		isyntax->valid_data_envelope_count = temp_envelopes_count;
+	}
 }

--- a/src/isyntax/isyntax.c
+++ b/src/isyntax/isyntax.c
@@ -613,7 +613,7 @@ static bool isyntax_parse_scannedimage_child_node(isyntax_t* isyntax, u32 group,
 					strncpy(isyntax->image_dimension_unit, value, MIN(value_len, sizeof(isyntax->image_dimension_unit) - 1));
 					isyntax->image_dimension_unit[MIN(value_len, sizeof(isyntax->image_dimension_unit) - 1)] = '\0';				} break;
 				case 0x2007: /*UFS_IMAGE_DIMENSION_SCALE_FACTOR*/           {
-					// TZwi: in data model >= 100 the macro and label images have their own scaling factor
+					// in data model >= 100 the macro and label images have their own scaling factor
 					float mpp = atof(value);
 					if (isyntax->parser.dimension_index == 0 /*x*/) {
 						image->mpp_x = mpp;

--- a/src/isyntax/isyntax.h
+++ b/src/isyntax/isyntax.h
@@ -211,7 +211,7 @@ typedef struct isyntax_cluster_header_template_t {
 } isyntax_cluster_header_template_t;
 
 typedef struct isyntax_valid_data_envelope_t {
-	v2i vertices[64];
+	v2i vertices[256];
 	i32 vertex_count;
 } isyntax_valid_data_envelope_t;
 
@@ -438,6 +438,7 @@ i32 isyntax_get_chunk_codeblocks_per_color_for_level(i32 level, bool has_ll);
 u8* isyntax_get_associated_image_pixels(isyntax_t* isyntax, isyntax_image_t* image, enum isyntax_pixel_format_t pixel_format);
 u8* isyntax_get_associated_image_jpeg(isyntax_t* isyntax, isyntax_image_t* image, u32* jpeg_size);
 u8* isyntax_get_icc_profile(isyntax_t* isyntax, isyntax_image_t* image, u32* icc_profile_size);
+void isyntax_parse_envelopes(isyntax_t* isyntax);
 
 
 #ifdef __cplusplus

--- a/src/isyntax/isyntax.h
+++ b/src/isyntax/isyntax.h
@@ -215,6 +215,13 @@ typedef struct isyntax_valid_data_envelope_t {
 	i32 vertex_count;
 } isyntax_valid_data_envelope_t;
 
+typedef struct isyntax_valid_data_envelope_rectangle_t {
+	v2i topleft;
+	v2i topright;
+	v2i bottomleft;
+	v2i bottomright;
+} isyntax_valid_data_envelope_rectangle_t;
+
 typedef struct isyntax_codeblock_t {
 	u32 x_coordinate;
 	u32 y_coordinate;
@@ -381,6 +388,8 @@ typedef struct isyntax_t {
 	i32 cluster_header_template_count;
 	isyntax_valid_data_envelope_t valid_data_envelopes[16];
 	i32 valid_data_envelope_count;
+	isyntax_valid_data_envelope_rectangle_t valid_data_envelopes_rectangles[128];
+	i32 valid_data_envelope_rectangle_count;
 	i32 macro_image_index;
 	i32 label_image_index;
 	i32 wsi_image_index;
@@ -438,7 +447,7 @@ i32 isyntax_get_chunk_codeblocks_per_color_for_level(i32 level, bool has_ll);
 u8* isyntax_get_associated_image_pixels(isyntax_t* isyntax, isyntax_image_t* image, enum isyntax_pixel_format_t pixel_format);
 u8* isyntax_get_associated_image_jpeg(isyntax_t* isyntax, isyntax_image_t* image, u32* jpeg_size);
 u8* isyntax_get_icc_profile(isyntax_t* isyntax, isyntax_image_t* image, u32* icc_profile_size);
-void isyntax_parse_envelopes(isyntax_t* isyntax);
+void isyntax_envelopes_to_rectangles(isyntax_t* isyntax);
 
 
 #ifdef __cplusplus

--- a/src/isyntax/isyntax.h
+++ b/src/isyntax/isyntax.h
@@ -215,13 +215,6 @@ typedef struct isyntax_valid_data_envelope_t {
 	i32 vertex_count;
 } isyntax_valid_data_envelope_t;
 
-typedef struct isyntax_valid_data_envelope_rectangle_t {
-	v2i topleft;
-	v2i topright;
-	v2i bottomleft;
-	v2i bottomright;
-} isyntax_valid_data_envelope_rectangle_t;
-
 typedef struct isyntax_codeblock_t {
 	u32 x_coordinate;
 	u32 y_coordinate;
@@ -393,7 +386,7 @@ typedef struct isyntax_t {
 	i32 cluster_header_template_count;
 	isyntax_valid_data_envelope_t valid_data_envelopes[16];
 	i32 valid_data_envelope_count;
-	isyntax_valid_data_envelope_rectangle_t valid_data_envelopes_rectangles[128];
+	rect2i valid_data_envelopes_rectangles[64];
 	i32 valid_data_envelope_rectangle_count;
 	i32 macro_image_index;
 	i32 label_image_index;
@@ -452,7 +445,7 @@ i32 isyntax_get_chunk_codeblocks_per_color_for_level(i32 level, bool has_ll);
 u8* isyntax_get_associated_image_pixels(isyntax_t* isyntax, isyntax_image_t* image, enum isyntax_pixel_format_t pixel_format);
 u8* isyntax_get_associated_image_jpeg(isyntax_t* isyntax, isyntax_image_t* image, u32* jpeg_size);
 u8* isyntax_get_icc_profile(isyntax_t* isyntax, isyntax_image_t* image, u32* icc_profile_size);
-void isyntax_envelopes_to_rectangles(isyntax_t* isyntax);
+void isyntax_envelopes_to_rect(isyntax_t* isyntax);
 
 
 #ifdef __cplusplus

--- a/src/isyntax/isyntax.h
+++ b/src/isyntax/isyntax.h
@@ -312,6 +312,11 @@ typedef struct isyntax_image_t {
 	i32 width;
 	i32 height;
 	i32 level0_padding;
+	float mpp_x;
+	float mpp_y;
+	bool is_mpp_known;
+	i32 origin_x;
+	i32 origin_y;
 	i32 offset_x;
 	i32 offset_y;
 	i32 level_count;

--- a/src/isyntax/isyntax.h
+++ b/src/isyntax/isyntax.h
@@ -386,7 +386,7 @@ typedef struct isyntax_t {
 	i32 cluster_header_template_count;
 	isyntax_valid_data_envelope_t valid_data_envelopes[16];
 	i32 valid_data_envelope_count;
-	rect2i valid_data_envelopes_rectangles[64];
+	rect2i valid_data_envelopes_rectangles[128];
 	i32 valid_data_envelope_rectangle_count;
 	i32 macro_image_index;
 	i32 label_image_index;


### PR DESCRIPTION
Improved the support of iSyntax v2 images, by:
* iSyntax v2 image data is stored as 9bit data values. Added bitshifting to 8bit RGBA/BGRA.
* sometimes the YCoCg decoding results in invalid negative numbers, this caused wrapping in the non-SIMD implementation.
(you can see the wrap around happening in parts of the image that are almost rgb(0,0,0))
* note: I added a SIMD implementation for Neon cpu's too, but please check. I am not able to debug that.
(todo: the wsi color is a bit dark, I am suspecting that the DICOM_ICCProfile needs to be implemented, but that is for a later)

Added support for iSyntax v2 macro and label images:
* In v2 the mpp_x and mmp_y values are no longer hardcoded and stored per image (and differ between wsi and label/macro), 
* mpp values are now properly extracted, stored (in image_t) and used for scaling
* the default position of the macro and label images also now also handled correctly

Added support for valid data envelopes:
* v2 images contain 'invalid' data areas, the valid_data_envelopes provide an outline of the 'valid' area
* parse the outline vectors into rectangles (extracting into polygons caused issues with holes, intersections, etc).
* the stencil buffer now uses those outlines to 'cut-out' the valid images
* sometimes (likely due to rounding) a black/grey outline appears, added some stencil magic to remove the outline (see comments for details)
* this is also implemented for non-iSyntax image formats, but there it just takes the image->width/height as the 'envelope' 

Minor additions: 
* Added an additional background between the macro and wsi image. This improves readability for de iSyntax v2 data as the valid data envelopes result in 'jagged' edges. 
(todo: the image->width/height return a size that is often smaller then the wsi image. Not sure why.)
* Added some debug options and moved the drawing flags into the app_state. 

Hope these additions are useful! 